### PR TITLE
Added SerializationMethodBuilder.

### DIFF
--- a/Obsidian.Tests/Deserialization.cs
+++ b/Obsidian.Tests/Deserialization.cs
@@ -1,0 +1,94 @@
+﻿using Obsidian.Net;
+using Obsidian.Net.Packets.Play;
+using Obsidian.Serializer;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Obsidian.Tests
+{
+    public class Deserialization
+    {
+        [Fact]
+        public void Handshake()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void LoginStart()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void EncryptionResponse()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public async Task IncomingChatMessage()
+        {
+            var message = "My chat message";
+
+            using var stream = new MinecraftStream();
+            await stream.WriteStringAsync(message);
+            stream.Position = 0;
+
+            var packet = PacketSerializer.FastDeserialize<IncomingChatMessage>(stream);
+
+            Assert.Equal(message, packet.Message);
+        }
+
+        [Fact]
+        public void ClientSettings()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void KeepAlive()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void PlayerPosition()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void PlayerPositionLook()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void PlayerLook()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void PlayerDigging()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void AnimationServerPacket()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void PlayerBlockPlacement()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Obsidian.Tests/Deserialization.cs
+++ b/Obsidian.Tests/Deserialization.cs
@@ -1,9 +1,6 @@
 ﻿using Obsidian.Net;
 using Obsidian.Net.Packets.Play;
 using Obsidian.Serializer;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,24 +8,6 @@ namespace Obsidian.Tests
 {
     public class Deserialization
     {
-        [Fact]
-        public void Handshake()
-        {
-            throw new NotImplementedException();
-        }
-
-        [Fact]
-        public void LoginStart()
-        {
-            throw new NotImplementedException();
-        }
-
-        [Fact]
-        public void EncryptionResponse()
-        {
-            throw new NotImplementedException();
-        }
-
         [Fact]
         public async Task IncomingChatMessage()
         {
@@ -43,52 +22,72 @@ namespace Obsidian.Tests
             Assert.Equal(message, packet.Message);
         }
 
-        [Fact]
-        public void ClientSettings()
-        {
-            throw new NotImplementedException();
-        }
+        // TODO: Implement other packets
 
-        [Fact]
-        public void KeepAlive()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void Handshake()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void PlayerPosition()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void LoginStart()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void PlayerPositionLook()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void EncryptionResponse()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void PlayerLook()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void ClientSettings()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void PlayerDigging()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void KeepAlive()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void AnimationServerPacket()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void PlayerPosition()
+        //{
+        //    throw new NotImplementedException();
+        //}
 
-        [Fact]
-        public void PlayerBlockPlacement()
-        {
-            throw new NotImplementedException();
-        }
+        //[Fact]
+        //public void PlayerPositionLook()
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //[Fact]
+        //public void PlayerLook()
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //[Fact]
+        //public void PlayerDigging()
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //[Fact]
+        //public void AnimationServerPacket()
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //[Fact]
+        //public void PlayerBlockPlacement()
+        //{
+        //    throw new NotImplementedException();
+        //}
     }
 }

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Obsidian.Serializer.Attributes;
+using Obsidian.Serializer.Enums;
+using System;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -7,6 +10,14 @@ namespace Obsidian.Net
     public partial class MinecraftStream
     {
 		public async Task<sbyte> ReadByteAsync() => (sbyte)await this.ReadUnsignedByteAsync();
+
+		[ReadMethod(DataType.UnsignedByte)]
+		public byte ReadUnsignedByte()
+        {
+			var buffer = new byte[1];
+			Read(buffer);
+			return buffer[0];
+        }
 
 		public async Task<byte> ReadUnsignedByteAsync()
 		{
@@ -109,6 +120,25 @@ namespace Obsidian.Net
 			return BitConverter.ToDouble(buffer);
 		}
 
+		[ReadMethod(DataType.String)]
+		public string ReadString(int maxLength = 0)
+        {
+			var length = ReadVarInt();
+			var buffer = new byte[length];
+			if (BitConverter.IsLittleEndian)
+			{
+				Array.Reverse(buffer);
+			}
+			Read(buffer, 0, length);
+
+			var value = Encoding.UTF8.GetString(buffer);
+			if (maxLength > 0 && value.Length > maxLength)
+			{
+				throw new ArgumentException($"string ({value.Length}) exceeded maximum length ({maxLength})", nameof(value));
+			}
+			return value;
+		}
+
 		public async Task<string> ReadStringAsync(int maxLength = 0)
 		{
 			var length = await this.ReadVarIntAsync();
@@ -125,6 +155,28 @@ namespace Obsidian.Net
 				throw new ArgumentException($"string ({value.Length}) exceeded maximum length ({maxLength})", nameof(value));
 			}
 			return value;
+		}
+
+		[ReadMethod(DataType.VarInt)]
+		public int ReadVarInt()
+        {
+			int numRead = 0;
+			int result = 0;
+			byte read;
+			do
+			{
+				read = ReadUnsignedByte();
+				int value = read & 0b01111111;
+				result |= value << (7 * numRead);
+
+				numRead++;
+				if (numRead > 5)
+				{
+					throw new InvalidOperationException("VarInt is too big");
+				}
+			} while ((read & 0b10000000) != 0);
+
+			return result;
 		}
 
 		public virtual async Task<int> ReadVarIntAsync()

--- a/Obsidian/Serializer/Attributes/IStreamMethod.cs
+++ b/Obsidian/Serializer/Attributes/IStreamMethod.cs
@@ -1,0 +1,9 @@
+﻿using Obsidian.Serializer.Enums;
+
+namespace Obsidian.Serializer.Attributes
+{
+    public interface IStreamMethod
+    {
+        public DataType Type { get; set; }
+    }
+}

--- a/Obsidian/Serializer/Attributes/ReadMethod.cs
+++ b/Obsidian/Serializer/Attributes/ReadMethod.cs
@@ -1,0 +1,16 @@
+﻿using Obsidian.Serializer.Enums;
+using System;
+
+namespace Obsidian.Serializer.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class ReadMethod : Attribute, IStreamMethod
+    {
+        public DataType Type { get; set; }
+
+        public ReadMethod(DataType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Obsidian/Serializer/Attributes/WriteMethod.cs
+++ b/Obsidian/Serializer/Attributes/WriteMethod.cs
@@ -1,0 +1,16 @@
+﻿using Obsidian.Serializer.Enums;
+using System;
+
+namespace Obsidian.Serializer.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class WriteMethod : Attribute, IStreamMethod
+    {
+        public DataType Type { get; set; }
+
+        public WriteMethod(DataType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Obsidian/Serializer/Dynamic/SerializationMethodBuilder.cs
+++ b/Obsidian/Serializer/Dynamic/SerializationMethodBuilder.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Collections.Generic;
+using Obsidian.Net;
+using Obsidian.Net.Packets;
+using Obsidian.Serializer.Attributes;
+using Obsidian.Util.Extensions;
+using Obsidian.Serializer.Enums;
+
+namespace Obsidian.Serializer.Dynamic
+{
+    internal static class SerializationMethodBuilder
+    {
+        private static readonly Dictionary<DataType, MethodInfo> writeMethods;
+        private static readonly Dictionary<DataType, MethodInfo> readMethods;
+
+        static SerializationMethodBuilder()
+        {
+            writeMethods = GetStreamMethods<WriteMethod>();
+            readMethods = GetStreamMethods<ReadMethod>();
+        }
+        
+        internal static MethodInfo BuildSerializationMethod<T>() where T : Packet
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static PacketSerializer.DeserializeDelegate BuildDeserializationMethod<T>() where T : Packet
+        {
+            var type = typeof(T);
+            var fields = GetFields(type).OrderBy((member) => member.Item2.Order);
+            var streamMethods = typeof(MinecraftStream).GetMethods(PacketExtensions.Flags);
+
+            var dynamicMethod = new DynamicMethod($"Deserialize{type.Name}",
+                                                  MethodAttributes.Public | MethodAttributes.Static,
+                                                  CallingConventions.Standard,
+                                                  returnType: type,
+                                                  parameterTypes: new[] { typeof(MinecraftStream) },
+                                                  owner: type,
+                                                  skipVisibility: true);
+            var il = dynamicMethod.GetILGenerator();
+
+            il.Emit(OpCodes.Newobj, type.GetConstructor(Array.Empty<Type>()));
+            il.Emit(OpCodes.Dup);
+
+            foreach (var (member, attribute) in fields)
+            {
+                if (member is FieldInfo field)
+                {
+                    DataType fieldType = attribute.Type != DataType.Auto ? attribute.Type : field.FieldType.ToDataType();
+                    if (fieldType == DataType.Auto || !readMethods.TryGetValue(fieldType, out var readMethod))
+                    {
+                        throw new NotSupportedException();
+                        continue;
+                    }
+                    
+                    il.Emit(OpCodes.Ldarg_0);
+                    var parameters = readMethod.GetParameters();
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        var parameterType = parameters[i].ParameterType;
+                        if (parameterType.IsByRef)
+                            il.Emit(OpCodes.Ldnull);
+                        else
+                            il.Emit(OpCodes.Ldc_I4_0);
+                    }
+                    il.Emit(OpCodes.Callvirt, readMethod);
+
+                    il.Emit(OpCodes.Stfld, field);
+                    il.Emit(OpCodes.Dup);
+                }
+                else if (member is PropertyInfo property)
+                {
+                    var setMethod = property.SetMethod;
+                    if (setMethod != null)
+                    {
+                        DataType propertyType = attribute.Type != DataType.Auto ? attribute.Type : property.PropertyType.ToDataType();
+                        if (propertyType == DataType.Auto || !readMethods.TryGetValue(propertyType, out var readMethod))
+                        {
+                            throw new NotSupportedException();
+                            continue;
+                        }
+
+                        il.Emit(OpCodes.Ldarg_0);
+                        var parameters = readMethod.GetParameters();
+                        for (int i = 0; i < parameters.Length; i++)
+                        {
+                            var parameterType = parameters[i].ParameterType;
+                            if (parameterType.IsByRef)
+                                il.Emit(OpCodes.Ldnull);
+                            else
+                                il.Emit(OpCodes.Ldc_I4_0);
+                        }
+                        il.Emit(OpCodes.Callvirt, readMethod);
+
+                        il.Emit(OpCodes.Callvirt, setMethod);
+                        il.Emit(OpCodes.Dup);
+                    }
+                }
+            }
+
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+
+            return (PacketSerializer.DeserializeDelegate)dynamicMethod.CreateDelegate(typeof(PacketSerializer.DeserializeDelegate));
+        }
+
+        private static IEnumerable<(MemberInfo, FieldAttribute)> GetFields(Type type)
+        {
+            foreach (var member in type.GetMembers(PacketExtensions.Flags))
+            {
+                var attribute = member.GetCustomAttribute<FieldAttribute>();
+                if (attribute != null)
+                {
+                    yield return (member, attribute);
+                }
+            }
+        }
+
+        private static Dictionary<DataType, MethodInfo> GetStreamMethods<T>() where T : Attribute, IStreamMethod
+        {
+            var dictionary = new Dictionary<DataType, MethodInfo>();
+            var methods = typeof(MinecraftStream).GetMethods(PacketExtensions.Flags);
+            for (int i = 0; i < methods.Length; i++)
+            {
+                var attribute = methods[i].GetCustomAttribute<T>();
+                if (attribute != null)
+                {
+                    dictionary.TryAdd(attribute.Type, methods[i]);
+                }
+            }
+            return dictionary;
+        }
+    }
+}

--- a/Obsidian/Util/PacketHandler.cs
+++ b/Obsidian/Util/PacketHandler.cs
@@ -83,7 +83,7 @@ namespace Obsidian.Util
 
                 case 0x02:
                     // Incoming chat message
-                    var message = await PacketSerializer.DeserializeAsync<IncomingChatMessage>(packet.data);
+                    var message = await PacketSerializer.FastDeserializeAsync<IncomingChatMessage>(packet.data);
 
                     await server.ParseMessage(message.Message, client);
                     break;


### PR DESCRIPTION
I added SerializationMethodBuilder, which uses DynamicMethods instead of Reflection to increase performance. I also added UnitTests for deserialization. So far, only IncomingChatMessage packet deserialization is implemented.

Usage is the same:
`var message = await PacketSerializer.FastDeserializeAsync<IncomingChatMessage>(packet.data);`