### PR TITLE
Add method to broadcast IChatMessage

### DIFF
--- a/Obsidian.API/_Interfaces/IPlayer.cs
+++ b/Obsidian.API/_Interfaces/IPlayer.cs
@@ -45,7 +45,7 @@ namespace Obsidian.API
 
         public Task TeleportAsync(Position position);
         public Task TeleportAsync(IPlayer to);
-        public Task SendMessageAsync(IChatMessage message, Guid? sender = null);
+        public Task SendMessageAsync(IChatMessage message, sbyte position = 0, Guid? sender = null);
         public Task SendMessageAsync(string message, sbyte position = 0, Guid? sender = null);
         public Task SendSoundAsync(int soundId, SoundPosition position, SoundCategory category = SoundCategory.Master, float pitch = 1f, float volume = 1f);
         public Task SendNamedSoundAsync(string name, SoundPosition position, SoundCategory category = SoundCategory.Master, float pitch = 1f, float volume = 1f);

--- a/Obsidian.API/_Interfaces/IServer.cs
+++ b/Obsidian.API/_Interfaces/IServer.cs
@@ -19,6 +19,7 @@ namespace Obsidian.API
         public bool IsPlayerOnline(string username);
         public bool IsPlayerOnline(Guid uuid);
         public Task BroadcastAsync(string message, sbyte position = 0);
+        public Task BroadcastAsync(IChatMessage message, sbyte position = 0);
         public IPlayer GetPlayer(string username);
         public IPlayer GetPlayer(Guid uuid);
         public void RegisterCommandClass<T>() where T : BaseCommandClass;

--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -239,15 +239,15 @@ namespace Obsidian.Entities
 
         public Task SendMessageAsync(string message, sbyte position = 0, Guid? sender = null) => client.QueuePacketAsync(new ChatMessagePacket(ChatMessage.Simple(message), position, sender ?? Guid.Empty));
 
-        public Task SendMessageAsync(IChatMessage message, Guid? sender = null)
+        public Task SendMessageAsync(IChatMessage message, sbyte position = 0, Guid? sender = null)
         {
             var chatMessage = message as ChatMessage;
             if (chatMessage is null)
                 return Task.FromException(new Exception("Message was of the wrong type or null. Expected instance supplied by IChatMessage.CreateNew."));
-            return SendMessageAsync(chatMessage, sender);
+            return SendMessageAsync(chatMessage, position, sender);
         }
 
-        public Task SendMessageAsync(ChatMessage message, Guid? sender = null) => client.QueuePacketAsync(new ChatMessagePacket(message, 0, sender ?? Guid.Empty));
+        public Task SendMessageAsync(ChatMessage message, sbyte position = 0, Guid? sender = null) => client.QueuePacketAsync(new ChatMessagePacket(message, position, sender ?? Guid.Empty));
 
         public Task SendSoundAsync(int soundId, SoundPosition position, SoundCategory category = SoundCategory.Master, float pitch = 1f, float volume = 1f) => client.QueuePacketAsync(new SoundEffect(soundId, position, category, pitch, volume));
 

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -39,7 +39,7 @@ namespace Obsidian
 {
     public struct QueueChat
     {
-        public string Message;
+        public IChatMessage Message;
         public sbyte Position;
     }
 
@@ -175,10 +175,18 @@ namespace Obsidian
         /// <summary>
         /// Sends a message to all players on the server.
         /// </summary>
-        public Task BroadcastAsync(string message, sbyte position = 0)
+        public Task BroadcastAsync(string message, sbyte position = 0) => BroadcastAsync(IChatMessage.Simple(message), position);
+        
+        /// <summary>
+        /// Sends a message to all players on the server.
+        /// </summary>
+        public Task BroadcastAsync(IChatMessage message, sbyte position = 0)
         {
+            if (message as ChatMessage is null)
+                return Task.FromException(new Exception("Message was of the wrong type or null. Expected instance supplied by IChatMessage.CreateNew."));
+
             this.chatMessages.Enqueue(new QueueChat() { Message = message, Position = position });
-            this.Logger.LogInformation(message);
+            this.Logger.LogInformation(message.Text);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
 - Added the `IServer.BroadcastAsync(IChatMessage message, sbyte position = 0)` method.
   - This method will throw if `message` is not an instance of `ChatMessage`.
- Modified `QueueChat` to use `IChatMessage` instead of `string` for `QueueChat.Message`