### PR TITLE
Typo fix

### DIFF
--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -158,7 +158,7 @@ namespace Obsidian
                             case 0x00:
                                 var status = new ServerStatus(Server);
 
-                                await this.Server.Events.InvokeServerServerStatusRequest(new ServerStatusRequestEventArgs(this.Server, status));
+                                await this.Server.Events.InvokeServerStatusRequest(new ServerStatusRequestEventArgs(this.Server, status));
 
                                 await this.SendPacketAsync(new RequestResponse(status));
                                 break;

--- a/Obsidian/Events/MinecraftEventHandler.cs
+++ b/Obsidian/Events/MinecraftEventHandler.cs
@@ -169,7 +169,7 @@ namespace Obsidian.Events
         internal Task InvokeServerTickAsync() =>
             this.serverTick.InvokeAsync();
 
-        internal async Task<ServerStatusRequestEventArgs> InvokeServerServerStatusRequest(ServerStatusRequestEventArgs eventargs)
+        internal async Task<ServerStatusRequestEventArgs> InvokeServerStatusRequest(ServerStatusRequestEventArgs eventargs)
         {
             await this.serverStatusRequest.InvokeAsync(eventargs);
 


### PR DESCRIPTION
The changes propose: Renaming **InvokeServerServerStatusRequest** method name to **InvokeServerStatusRequest**