### PR TITLE
/Gamemode, bug fixes

### DIFF
--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -106,7 +106,8 @@ namespace Obsidian
                 }
                 catch(Exception e)
                 {
-                    Logger.LogError(e.Message + "\n" + e.StackTrace);
+                    if (Globals.Config.VerboseLogging)
+                        Logger.LogError(e.Message + "\n" + e.StackTrace);
                 }
             },
             blockOptions);

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -99,8 +99,15 @@ namespace Obsidian
             packetQueue = new BufferBlock<IPacket>(blockOptions);
             var sendPacketBlock = new ActionBlock<IPacket>(async packet =>
             {
-                if (tcp.Connected)
-                    await SendPacketAsync(packet);
+				try
+				{
+                    if (tcp.Connected)
+                        await SendPacketAsync(packet);
+                }
+                catch(Exception e)
+				{
+                    Logger.LogError(e.Message + "\n" + e.StackTrace);
+				}
             },
             blockOptions);
 

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -99,15 +99,15 @@ namespace Obsidian
             packetQueue = new BufferBlock<IPacket>(blockOptions);
             var sendPacketBlock = new ActionBlock<IPacket>(async packet =>
             {
-				try
-				{
+                try
+                {
                     if (tcp.Connected)
                         await SendPacketAsync(packet);
                 }
                 catch(Exception e)
-				{
+                {
                     Logger.LogError(e.Message + "\n" + e.StackTrace);
-				}
+                }
             },
             blockOptions);
 

--- a/Obsidian/Net/MinecraftStream.cs
+++ b/Obsidian/Net/MinecraftStream.cs
@@ -255,7 +255,14 @@ namespace Obsidian.Net
                     }
                 case DataType.Float:
                     {
-                        await this.WriteFloatAsync((float)value);
+						if (value is Enum)
+						{
+							Enum _enum = (Enum)value;
+                            value = Convert.ChangeType(value, _enum.GetTypeCode());
+							await this.WriteFloatAsync(Convert.ToSingle(value));
+						}
+						else
+							await this.WriteFloatAsync((float)value);
                         break;
                     }
                 case DataType.Double:

--- a/Obsidian/Net/MinecraftStream.cs
+++ b/Obsidian/Net/MinecraftStream.cs
@@ -255,14 +255,14 @@ namespace Obsidian.Net
                     }
                 case DataType.Float:
                     {
-						if (value is Enum)
-						{
-							Enum _enum = (Enum)value;
+                        if (value is Enum)
+                        {
+                            Enum _enum = (Enum)value;
                             value = Convert.ChangeType(value, _enum.GetTypeCode());
-							await this.WriteFloatAsync(Convert.ToSingle(value));
-						}
-						else
-							await this.WriteFloatAsync((float)value);
+                            await this.WriteFloatAsync(Convert.ToSingle(value));
+                        }
+                        else
+                            await this.WriteFloatAsync((float)value);
                         break;
                     }
                 case DataType.Double:

--- a/Obsidian/Net/Packets/Play/Client/GameState/ChangeGamemodeState.cs
+++ b/Obsidian/Net/Packets/Play/Client/GameState/ChangeGamemodeState.cs
@@ -6,7 +6,7 @@ namespace Obsidian.Net.Packets.Play.Client.GameState
     {
         public override Gamemode Value { get; set; }
 
-        public ChangeGamemodeState(Gamemode newMode) => this.Value = newMode;
+        public ChangeGamemodeState(Gamemode newMode) : base(ChangeGameStateReason.ChangeGamemode) => this.Value = newMode;
     }
 
 }

--- a/Obsidian/Serializer/PacketSerializer.cs
+++ b/Obsidian/Serializer/PacketSerializer.cs
@@ -21,9 +21,8 @@ namespace Obsidian.Serializer
 
         public static async Task SerializeAsync(IPacket packet, MinecraftStream stream)
         {
-
-			try
-			{
+            try
+            {
                 if (packet == null)
                     throw new ArgumentNullException(nameof(packet));
 
@@ -65,12 +64,12 @@ namespace Obsidian.Serializer
 
                 await dataStream.CopyToAsync(stream);
             }
-			catch
-			{
+            catch
+            {
                 throw;
 			}
-			finally
-			{
+            finally
+            {
                 stream.Lock.Release();
             }
         }

--- a/Obsidian/Serializer/PacketSerializer.cs
+++ b/Obsidian/Serializer/PacketSerializer.cs
@@ -67,7 +67,7 @@ namespace Obsidian.Serializer
             catch
             {
                 throw;
-			}
+            }
             finally
             {
                 stream.Lock.Release();

--- a/Obsidian/Util/GlobalConfig.cs
+++ b/Obsidian/Util/GlobalConfig.cs
@@ -18,5 +18,10 @@ namespace Obsidian.Util
 
         [JsonProperty("debugMode")]
         public bool DebugMode;
+
+
+        [JsonProperty("verboseExceptionLogging")]
+        public bool VerboseLogging { get; set; } = false;
+
     }
 }

--- a/Obsidian/Util/PacketHandler.cs
+++ b/Obsidian/Util/PacketHandler.cs
@@ -3,6 +3,7 @@ using Obsidian.Net;
 using Obsidian.Net.Packets;
 using Obsidian.Net.Packets.Play;
 using Obsidian.Net.Packets.Play.Server;
+using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
@@ -86,8 +87,16 @@ namespace Obsidian
             if (!Packets.ContainsKey(packet.id))
                 return;
 
-            await Packets[packet.id].ReadAsync(new MinecraftStream(packet.data));
-            await Packets[packet.id].HandleAsync(client.Server, client.Player);
+			try
+            {
+                await Packets[packet.id].ReadAsync(new MinecraftStream(packet.data));
+                await Packets[packet.id].HandleAsync(client.Server, client.Player);
+            }
+			catch(Exception e)
+			{
+                Logger.LogError(e.Message + "\n" + e.StackTrace);
+			}
+
         }
 
     }

--- a/Obsidian/Util/PacketHandler.cs
+++ b/Obsidian/Util/PacketHandler.cs
@@ -3,6 +3,7 @@ using Obsidian.Net;
 using Obsidian.Net.Packets;
 using Obsidian.Net.Packets.Play;
 using Obsidian.Net.Packets.Play.Server;
+using Obsidian.Util;
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
@@ -94,7 +95,8 @@ namespace Obsidian
             }
             catch(Exception e)
             {
-                Logger.LogError(e.Message + "\n" + e.StackTrace);
+                if (Globals.Config.VerboseLogging)
+                    Logger.LogError(e.Message + "\n" + e.StackTrace);
             }
 
         }

--- a/Obsidian/Util/PacketHandler.cs
+++ b/Obsidian/Util/PacketHandler.cs
@@ -87,15 +87,15 @@ namespace Obsidian
             if (!Packets.ContainsKey(packet.id))
                 return;
 
-			try
+            try
             {
                 await Packets[packet.id].ReadAsync(new MinecraftStream(packet.data));
                 await Packets[packet.id].HandleAsync(client.Server, client.Player);
             }
-			catch(Exception e)
-			{
+            catch(Exception e)
+            {
                 Logger.LogError(e.Message + "\n" + e.StackTrace);
-			}
+            }
 
         }
 

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -51,7 +51,7 @@ namespace Obsidian.WorldData
             this.Server = server;
         }
 
-        public int TotalLoadedEntities() => this.Regions.Select(x => x.Value).Sum(e => e.Entities.Count);
+        public int TotalLoadedEntities() => this.Regions.Values.Sum(e => e == null ? 0 : e.Entities.Count);
 
         public async Task UpdateClientChunksAsync(Client c, bool unloadAll = false)
         {


### PR DESCRIPTION
Changes
  - Exceptions in HandlePlayPackets used to prevent future incoming packets from being handled
  - World#TotalLoadedEntites used to throw a null ref exception when not all regions are loaded (causing the server to crash if you joined before all regions were loaded.) Now if not all regions are loaded, you will not get sent all chunk data, but you can rejoin to fix this.
  - Exceptions in sendPacketBlock are now logged
  - PacketSerializer.SerializeAsync will now unlock MinecraftStream if there's an exception
  - Added conversion in MinecraftStream from enum to float. (This might be something that should be generalized to more dataTypes?)