### PR TITLE
Implement broadcasting over LAN

### DIFF
--- a/Obsidian/Utilities/Config.cs
+++ b/Obsidian/Utilities/Config.cs
@@ -53,5 +53,8 @@ namespace Obsidian.Utilities
 
         [JsonProperty("downloadplugins")]
         public string[] DownloadPlugins { get; set; } = Array.Empty<string>();
+
+        [JsonProperty("udpBroadcast")]
+        public bool UDPBroadcast = false;
     }
 }


### PR DESCRIPTION
This adds an UDP client that keeps broadcasting an UDP packet until the server closes.

As documented here: https://wiki.vg/Server_List_Ping#Ping_via_LAN_(Open_to_LAN_in_Singleplayer)