### PR TITLE
Remove DaanV2.UUID.Net dependency

### DIFF
--- a/Obsidian.Tests/Obsidian.Tests.csproj
+++ b/Obsidian.Tests/Obsidian.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Obsidian.Tests/Obsidian.Tests.csproj
+++ b/Obsidian.Tests/Obsidian.Tests.csproj
@@ -17,9 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Obsidian.Tests/Utilities/GuidHelperTests.cs
+++ b/Obsidian.Tests/Utilities/GuidHelperTests.cs
@@ -1,0 +1,52 @@
+﻿using Obsidian.Utilities;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Obsidian.Tests.Utilities
+{
+    public class GuidHelperTests
+    {
+        public static IEnumerable<object[]> Data => new string[][]
+        {
+            new[] { string.Empty },
+            new[] { "ABCDE" },
+            new[] { "0123456789ABCDEF" }
+        };
+
+        [Fact(DisplayName = "Passing null throws an exception")]
+        public void NullThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => GuidHelper.FromStringHash(null));
+            Assert.Throws<ArgumentNullException>(() => GuidHelper.FromStringHashCryptographic(null));
+        }
+
+        [MemberData(nameof(Data))]
+        [Theory(DisplayName = "Creating GUID from string hash")]
+        public void GuidFromStringHash(string text)
+        {
+            Guid guid = GuidHelper.FromStringHash(text);
+            Assert.NotEqual(Guid.Empty, guid);
+
+            Guid guid2 = GuidHelper.FromStringHash(text);
+            Assert.Equal(guid, guid2);
+
+            Guid guid3 = GuidHelper.FromStringHash(text + "_");
+            Assert.NotEqual(guid, guid3);
+        }
+
+        [MemberData(nameof(Data))]
+        [Theory(DisplayName = "Creating GUID from string hash using cryptography")]
+        public void GuidFromStringHashCryptographic(string text)
+        {
+            Guid guid = GuidHelper.FromStringHashCryptographic(text);
+            Assert.NotEqual(Guid.Empty, guid);
+
+            Guid guid2 = GuidHelper.FromStringHashCryptographic(text);
+            Assert.Equal(guid, guid2);
+
+            Guid guid3 = GuidHelper.FromStringHashCryptographic(text + "_");
+            Assert.NotEqual(guid, guid3);
+        }
+    }
+}

--- a/Obsidian.Tests/Utilities/GuidHelperTests.cs
+++ b/Obsidian.Tests/Utilities/GuidHelperTests.cs
@@ -1,28 +1,38 @@
 ﻿using Obsidian.Utilities;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Obsidian.Tests.Utilities
 {
     public class GuidHelperTests
     {
-        public static IEnumerable<object[]> Data => new string[][]
-        {
-            new[] { string.Empty },
-            new[] { "ABCDE" },
-            new[] { "0123456789ABCDEF" }
-        };
-
         [Fact(DisplayName = "Passing null throws an exception")]
         public void NullThrows()
         {
             Assert.Throws<ArgumentNullException>(() => GuidHelper.FromStringHash(null));
-            Assert.Throws<ArgumentNullException>(() => GuidHelper.FromStringHashCryptographic(null));
         }
 
-        [MemberData(nameof(Data))]
+        [Theory(DisplayName = "Getting version from GUID")]
+        [InlineData(0, "00000000-0000-0000-0000-000000000000")]
+        [InlineData(1, "29dafd90-c321-11eb-8529-0242ac130003")]
+        [InlineData(3, "1e0ca5b1-252f-3f6b-9e0a-c91be7e7219e")]
+        public void GetVersion(int expectedVersion, string guid)
+        {
+            Assert.Equal(expectedVersion, GuidHelper.GetVersion(new Guid(guid)));
+        }
+
+        [Theory(DisplayName = "Getting variant of GUID")]
+        [InlineData(0, "00000000-0000-0000-0000-000000000000")]
+        [InlineData(1, "29dafd90-c321-11eb-8529-0242ac130003")]
+        [InlineData(1, "1e0ca5b1-252f-3f6b-9e0a-c91be7e7219e")]
+        public void GetVariant(int expectedVariant, string guid)
+        {
+            Assert.Equal(expectedVariant, GuidHelper.GetVariant(new Guid(guid)));
+        }
+
         [Theory(DisplayName = "Creating GUID from string hash")]
+        [InlineData("")]
+        [InlineData("0123456789ABCDEF")]
         public void GuidFromStringHash(string text)
         {
             Guid guid = GuidHelper.FromStringHash(text);
@@ -33,20 +43,9 @@ namespace Obsidian.Tests.Utilities
 
             Guid guid3 = GuidHelper.FromStringHash(text + "_");
             Assert.NotEqual(guid, guid3);
-        }
 
-        [MemberData(nameof(Data))]
-        [Theory(DisplayName = "Creating GUID from string hash using cryptography")]
-        public void GuidFromStringHashCryptographic(string text)
-        {
-            Guid guid = GuidHelper.FromStringHashCryptographic(text);
-            Assert.NotEqual(Guid.Empty, guid);
-
-            Guid guid2 = GuidHelper.FromStringHashCryptographic(text);
-            Assert.Equal(guid, guid2);
-
-            Guid guid3 = GuidHelper.FromStringHashCryptographic(text + "_");
-            Assert.NotEqual(guid, guid3);
+            Assert.Equal(3, GuidHelper.GetVersion(guid));
+            Assert.Equal(1, GuidHelper.GetVariant(guid));
         }
     }
 }

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -1,6 +1,4 @@
-﻿using DaanV2.UUID;
-
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 using Obsidian.API;
 using Obsidian.API.Events;
@@ -231,7 +229,7 @@ namespace Obsidian
                                     break;
                                 }
 
-                                this.Player = new Player(UUIDFactory.CreateUUID(3, 1, $"OfflinePlayer:{username}"), username, this)
+                                this.Player = new Player(GuidHelper.FromStringHash($"OfflinePlayer:{username}"), username, this)
                                 {
                                     World = this.Server.World
                                 };

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -52,7 +52,6 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.3.1" />
-    <PackageReference Include="DaanV2.UUID.Net" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />

--- a/Obsidian/Utilities/GuidHelper.cs
+++ b/Obsidian/Utilities/GuidHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Obsidian.Utilities
+{
+    public static class GuidHelper
+    {
+        private static HashAlgorithm hashAlgorithm;
+
+        public static Guid FromStringHash(string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            int hash = text.GetHashCode();
+
+            var i128 = new Int128
+            {
+                a = HashCode.Combine(hash, 0),
+                b = HashCode.Combine(hash, 256),
+                c = HashCode.Combine(hash, 65536),
+                d = HashCode.Combine(hash, 16777216)
+            };
+
+            return Unsafe.As<Int128, Guid>(ref i128);
+        }
+
+        public static Guid FromStringHashCryptographic(string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            var i128 = new Int128();
+
+            hashAlgorithm ??= MD5.Create();
+
+            hashAlgorithm.TryComputeHash(text.AsByteSpan(), i128.AsSpan(), out _);
+
+            return Unsafe.As<Int128, Guid>(ref i128);
+        }
+
+        private static ReadOnlySpan<byte> AsByteSpan(this string text)
+        {
+            ref char charPtr = ref Unsafe.AsRef(text.GetPinnableReference());
+            ref byte ptr = ref Unsafe.As<char, byte>(ref charPtr);
+            return MemoryMarshal.CreateReadOnlySpan(ref ptr, text.Length * 2);
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct Int128
+        {
+            [FieldOffset(0)]
+            public int a;
+            [FieldOffset(4)]
+            public int b;
+            [FieldOffset(8)]
+            public int c;
+            [FieldOffset(12)]
+            public int d;
+
+            [FieldOffset(0)]
+            private byte start;
+
+            public Span<byte> AsSpan()
+            {
+                return MemoryMarshal.CreateSpan(ref start, 16);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, `DaanV2.UUID.Net` package is only used for generating `Guid`s from a string hash. The whole package does a lot more, but is only used as this simple utility. I added two implementations, one using cryptography (MD5) as `DaanV2` did. I would only choose one of them, not sure which one though.

Simple hash:
```diff
+ Simple
+ Fast
- Implementation dependent, results might change with different versions of .NET
```

Cryptographic hash:
```diff
+ Should always get consistent results
+ Somewhat stronger hash (not sure how important this is)
- Slower
```

I would appreciate your feedback.