### PR TITLE
Changed BitConverter to BinaryPrimitives

### DIFF
--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -6,6 +6,7 @@ using Obsidian.Serialization.Attributes;
 using Obsidian.Utilities;
 using Obsidian.Utilities.Registry;
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -63,22 +64,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[2];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToUInt16(buffer);
+            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
         }
 
         public async Task<ushort> ReadUnsignedShortAsync()
         {
             var buffer = new byte[2];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToUInt16(buffer);
+            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
         }
 
         [ReadMethod]
@@ -86,22 +79,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[2];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToInt16(buffer);
+            return BinaryPrimitives.ReadInt16BigEndian(buffer);
         }
 
         public async Task<short> ReadShortAsync()
         {
             var buffer = new byte[2];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToInt16(buffer);
+            return BinaryPrimitives.ReadInt16BigEndian(buffer);
         }
 
         [ReadMethod]
@@ -109,22 +94,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[4];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToInt32(buffer);
+            return BinaryPrimitives.ReadInt32BigEndian(buffer);
         }
 
         public async Task<int> ReadIntAsync()
         {
             var buffer = new byte[4];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToInt32(buffer);
+            return BinaryPrimitives.ReadInt32BigEndian(buffer);
         }
 
         [ReadMethod]
@@ -132,22 +109,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[8];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToInt64(buffer);
+            return BinaryPrimitives.ReadInt64BigEndian(buffer);
         }
 
         public async Task<long> ReadLongAsync()
         {
             var buffer = new byte[8];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToInt64(buffer);
+            return BinaryPrimitives.ReadInt64BigEndian(buffer);
         }
 
         [ReadMethod]
@@ -155,22 +124,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[8];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToUInt64(buffer);
+            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
         }
 
         public async Task<ulong> ReadUnsignedLongAsync()
         {
             var buffer = new byte[8];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToUInt64(buffer);
+            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
         }
 
         [ReadMethod]
@@ -178,22 +139,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[4];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToSingle(buffer);
+            return BinaryPrimitives.ReadSingleBigEndian(buffer);
         }
 
         public async Task<float> ReadFloatAsync()
         {
             var buffer = new byte[4];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToSingle(buffer);
+            return BinaryPrimitives.ReadSingleBigEndian(buffer);
         }
 
         [ReadMethod]
@@ -201,22 +154,14 @@ namespace Obsidian.Net
         {
             Span<byte> buffer = stackalloc byte[8];
             this.Read(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                buffer.Reverse();
-            }
-            return BitConverter.ToDouble(buffer);
+            return BinaryPrimitives.ReadDoubleBigEndian(buffer);
         }
 
         public async Task<double> ReadDoubleAsync()
         {
             var buffer = new byte[8];
             await this.ReadAsync(buffer);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
-            return BitConverter.ToDouble(buffer);
+            return BinaryPrimitives.ReadDoubleBigEndian(buffer);
         }
 
         [ReadMethod]
@@ -224,10 +169,6 @@ namespace Obsidian.Net
         {
             var length = ReadVarInt();
             var buffer = new byte[length];
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(buffer);
-            }
             this.Read(buffer, 0, length);
 
             var value = Encoding.UTF8.GetString(buffer);

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -12,6 +12,7 @@ using Obsidian.Serialization.Attributes;
 using Obsidian.Utilities;
 using Obsidian.Utilities.Registry.Codecs.Dimensions;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -70,11 +71,7 @@ namespace Obsidian.Net
         public void WriteUnsignedShort(ushort value)
         {
             Span<byte> span = stackalloc byte[2];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteUInt16BigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -84,11 +81,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing unsigned Short ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16BigEndian(write, value);
             await WriteAsync(write);
         }
 
@@ -96,11 +90,7 @@ namespace Obsidian.Net
         public void WriteShort(short value)
         {
             Span<byte> span = stackalloc byte[2];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteInt16BigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -110,11 +100,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Short ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16BigEndian(write, value);
             await WriteAsync(write);
         }
 
@@ -122,11 +109,7 @@ namespace Obsidian.Net
         public void WriteInt(int value)
         {
             Span<byte> span = stackalloc byte[4];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteInt32BigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -136,11 +119,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Int ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(write, value);
             await WriteAsync(write);
         }
 
@@ -148,11 +128,7 @@ namespace Obsidian.Net
         public void WriteLong(long value)
         {
             Span<byte> span = stackalloc byte[8];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteInt64BigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -162,11 +138,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Long ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64BigEndian(write, value);
             await WriteAsync(write);
         }
 
@@ -174,11 +147,7 @@ namespace Obsidian.Net
         public void WriteFloat(float value)
         {
             Span<byte> span = stackalloc byte[4];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteSingleBigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -188,11 +157,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Float ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(float)];
+            BinaryPrimitives.WriteSingleBigEndian(write, value);
             await WriteAsync(write);
         }
 
@@ -200,11 +166,7 @@ namespace Obsidian.Net
         public void WriteDouble(double value)
         {
             Span<byte> span = stackalloc byte[8];
-            BitConverter.TryWriteBytes(span, value);
-            if (BitConverter.IsLittleEndian)
-            {
-                span.Reverse();
-            }
+            BinaryPrimitives.WriteDoubleBigEndian(span, value);
             BaseStream.Write(span);
         }
 
@@ -214,11 +176,8 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Double ({value})");
 #endif
 
-            var write = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(write);
-            }
+            var write = new byte[sizeof(double)];
+            BinaryPrimitives.WriteDoubleBigEndian(write, value);
             await WriteAsync(write);
         }
 


### PR DESCRIPTION
Using BinaryPrimitives instead of BitConverter + reverse can speed up the the encoding/decoding of primitives from 300ns to 0.2ns