### PR TITLE
[Important] Implement URL encoding for Mojang API requests.

### DIFF
--- a/Obsidian/Utilities/Mojang/MinecraftAPI.cs
+++ b/Obsidian/Utilities/Mojang/MinecraftAPI.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace Obsidian.Utilities.Mojang
 {
@@ -13,28 +14,38 @@ namespace Obsidian.Utilities.Mojang
 
         public static async Task<List<MojangUser>> GetUsersAsync(string[] usernames)
         {
-            using HttpResponseMessage response = await Http.PostAsync("https://api.mojang.com/profiles/minecraft", new StringContent(JsonSerializer.Serialize(usernames), Encoding.UTF8, "application/json"));
+            var escaped_usernames = new List<string>();
+
+            for (int i = 0; i < usernames.Length; i++)
+                escaped_usernames.Add(HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(usernames[i])));
+
+            using HttpResponseMessage response = await Http.PostAsync("https://api.mojang.com/profiles/minecraft", new StringContent(JsonSerializer.Serialize(escaped_usernames), Encoding.UTF8, "application/json"));
 
             return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<List<MojangUser>>() : null;
         }
 
         public static async Task<MojangUser> GetUserAsync(string username)
         {
-            var users = await GetUsersAsync(new[] { username });
+            var escaped_username = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
+            var users = await GetUsersAsync(new[] { escaped_username });
 
             return (users == null || users.Count <= 0) ? null : users.FirstOrDefault();
         }
 
         public static async Task<MojangUser> GetUserAndSkinAsync(string uuid)
         {
-            using HttpResponseMessage response = await Http.GetAsync("https://sessionserver.mojang.com/session/minecraft/profile/" + uuid);
+            var escaped_uuid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(uuid)); 
+            // I'm fairly sure this is not exploitable, but good practice and consistency are two important factors imo
+            using HttpResponseMessage response = await Http.GetAsync("https://sessionserver.mojang.com/session/minecraft/profile/" + escaped_uuid);
 
             return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<MojangUser>() : null;
         }
 
         public static async Task<JoinedResponse> HasJoined(string username, string serverId)
         {
-            using HttpResponseMessage response = await Http.GetAsync($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={serverId}");
+            var escaped_username = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
+            var escaped_serverid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(serverId));
+            using HttpResponseMessage response = await Http.GetAsync($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={escaped_username}&serverId={escaped_serverid}");
 
             return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<JoinedResponse>() : null;
         }


### PR DESCRIPTION
I've been informed about a vulnerability in how Obsidian does API requests to Mojang. I won't be going into much detail as requested, but it is of importance that this fix gets merged ASAP.

Because of this, I will be merging this PR without review for once. Other main devs can DM me about the details, if they wish to do so.