### PR TITLE
Add ConcurrentMap

### DIFF
--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -15,6 +15,7 @@ using Obsidian.Net.Packets.Play.Clientbound;
 using Obsidian.Net.Packets.Play.Serverbound;
 using Obsidian.Plugins;
 using Obsidian.Utilities;
+using Obsidian.Utilities.Concurrency;
 using Obsidian.Utilities.Debug;
 using Obsidian.Utilities.Registry;
 using Obsidian.WorldData;
@@ -62,7 +63,7 @@ namespace Obsidian
 
         internal ConcurrentDictionary<Guid, Inventory> CachedWindows { get; } = new ConcurrentDictionary<Guid, Inventory>();
 
-        public ConcurrentDictionary<Guid, Player> OnlinePlayers { get; } = new ConcurrentDictionary<Guid, Player>();
+        public ConcurrentMap<Guid, Player> OnlinePlayers { get; } = new();
 
         public ConcurrentDictionary<string, World> Worlds { get; private set; } = new ConcurrentDictionary<string, World>();
 
@@ -184,7 +185,7 @@ namespace Obsidian
 
         public IPlayer GetPlayer(string username) => this.OnlinePlayers.FirstOrDefault(player => player.Value.Username == username).Value;
 
-        public IPlayer GetPlayer(Guid uuid) => this.OnlinePlayers.TryGetValue(uuid, out var player) ? player : null;
+        public IPlayer GetPlayer(Guid uuid) => this.OnlinePlayers.TryGet(uuid, out var player) ? player : null;
 
         public IPlayer GetPlayer(int entityId) => this.OnlinePlayers.FirstOrDefault(player => player.Value.EntityId == entityId).Value;
 
@@ -432,7 +433,7 @@ namespace Obsidian
         {
             var digging = store.Packet;
 
-            var player = this.OnlinePlayers.GetValueOrDefault(store.Player);
+            OnlinePlayers.TryGet(store.Player, out Player player);
 
             switch (digging.Status)
             {

--- a/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
+++ b/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
@@ -68,6 +68,14 @@ namespace Obsidian.Utilities.Concurrency
             return success;
         }
 
+        public bool ContainsKey(TKey key)
+        {
+            mapLock.EnterReadLock();
+            bool hasKey = key is not null && map.ContainsKey(key);
+            mapLock.ExitReadLock();
+            return hasKey;
+        }
+
         public void Dispose()
         {
             mapLock.Dispose();

--- a/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
+++ b/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace Obsidian.Utilities.Concurrency
@@ -10,6 +11,7 @@ namespace Obsidian.Utilities.Concurrency
     public sealed class ConcurrentMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>, IDisposable where TKey : notnull
     {
         public int Count => map.Count;
+        public IEnumerable<TValue> Values => this.Select(pair => pair.Value);
 
         private readonly ReaderWriterLockSlim mapLock = new();
         private readonly Dictionary<TKey, TValue> map = new();

--- a/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
+++ b/Obsidian/Utilities/Concurrency/ConcurrentMap.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Obsidian.Utilities.Concurrency
+{
+    public sealed class ConcurrentMap<TKey, TValue> : IDisposable
+    {
+        public int Count => map.Count;
+
+        private readonly ReaderWriterLockSlim mapLock = new();
+        private readonly Dictionary<TKey, TValue> map = new();
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                mapLock.EnterReadLock();
+                try
+                {
+                    return map[key];
+                }
+                finally
+                {
+                    mapLock.ExitReadLock();
+                }
+            }
+
+            set
+            {
+                mapLock.EnterWriteLock();
+                try
+                {
+                    map[key] = value;
+                }
+                finally
+                {
+                    mapLock.ExitWriteLock();
+                }
+            }
+        }
+
+        public bool TryAdd(TKey key, TValue value)
+        {
+            mapLock.EnterWriteLock();
+            bool success = key is not null && map.TryAdd(key, value);
+            mapLock.ExitWriteLock();
+            return success;
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            value = default;
+            mapLock.EnterReadLock();
+            bool success = key is not null && map.TryGetValue(key, out value);
+            mapLock.ExitReadLock();
+            return success;
+        }
+
+        public bool TryRemove(TKey key)
+        {
+            mapLock.EnterWriteLock();
+            bool success = key is not null && map.Remove(key);
+            mapLock.ExitWriteLock();
+            return success;
+        }
+
+        public void Dispose()
+        {
+            mapLock.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        ~ConcurrentMap()
+        {
+            mapLock.Dispose();
+        }
+    }
+}

--- a/Obsidian/Utilities/Extensions.cs
+++ b/Obsidian/Utilities/Extensions.cs
@@ -100,12 +100,12 @@ namespace Obsidian.Utilities
             return Registry.Registry.GetItem(itemStack.Type);
         }
 
-        public static IEnumerable<KeyValuePair<Guid, Player>> Except(this ConcurrentDictionary<Guid, Player> source, params Guid[] uuids)
+        public static IEnumerable<KeyValuePair<Guid, Player>> Except(this IEnumerable<KeyValuePair<Guid, Player>> source, params Guid[] uuids)
         {
             return source.Where(x => !uuids.Contains(x.Value.Uuid));
         }
 
-        public static IEnumerable<KeyValuePair<Guid, Player>> Except(this ConcurrentDictionary<Guid, Player> source, params Player[] players)
+        public static IEnumerable<KeyValuePair<Guid, Player>> Except(this IEnumerable<KeyValuePair<Guid, Player>> source, params Player[] players)
         {
             var newDict = new Dictionary<Guid, Player>();
             foreach ((Guid uuid, Player player) in source)


### PR DESCRIPTION
Adds new utility collection - `ConcurrentMap`. Internally it uses a `ReaderWriterLockSlim`, which should be more efficient in some cases, as it allows for multiple concurrent reads.

Possible issues:
- Adding more complexity → more possibilities for bugs (enumerations are difficult to get right)
- Name may be confusing, as it's hard to tell apart from `ConcurrentDictionary`

TODO
- [ ] Use for other often-read-rarely-changed dictionaries throughout codebase
- [ ] Test in action
- [ ] Add unit tests (?)