### PR TITLE
Simplify Permission

### DIFF
--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -738,7 +738,7 @@ namespace Obsidian.Entities
 
             foreach (var permission in permissions)
             {
-                if (parent.Children.Any(x => x.Name == "*") || parent.Children.Any(x => x.Name.EqualsIgnoreCase(permission)))
+                if (parent.Children.Any(x => x.Name == Permission.Wildcard) || parent.Children.Any(x => x.Name.EqualsIgnoreCase(permission)))
                     return true;
 
                 parent = parent.Children.First(x => x.Name.EqualsIgnoreCase(permission));

--- a/Obsidian/Utilities/Permission.cs
+++ b/Obsidian/Utilities/Permission.cs
@@ -2,16 +2,10 @@
 
 namespace Obsidian.Utilities
 {
-    public class Permission
+    public record Permission(string Name)
     {
-        public string Name { get; set; }
+        public static readonly string Wildcard = "*";
 
-        public List<Permission> Children { get; set; }
-
-        public Permission(string name)
-        {
-            this.Name = name;
-            this.Children = new List<Permission>();
-        }
+        public List<Permission> Children { get; } = new();
     }
 }


### PR DESCRIPTION
Remove boilerplate by turning `Permission` into a `record`.