### PR TITLE
Compiler Warnings Clean up

### DIFF
--- a/Obsidian.API/Crafting/Builders/CuttingRecipeBuilder.cs
+++ b/Obsidian.API/Crafting/Builders/CuttingRecipeBuilder.cs
@@ -57,14 +57,14 @@ namespace Obsidian.API.Crafting.Builders
                 throw new InvalidOperationException("Recipe must atleast have 1 item as an ingredient");
 
             return new CuttingRecipe
-            {
-                Name = this.Name ?? throw new NullReferenceException("Name must not be null"),
-                Type = CraftingType.Stonecutting,
-                Group = this.Group,
-                Ingredient = this.Ingredient ?? throw new NullReferenceException("Ingredient must not be null"),
-                Count = this.Count,
-                Result = this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set.")
-            };
+            (
+                this.Name ?? throw new NullReferenceException("Name must not be null"),
+                CraftingType.Stonecutting,
+                this.Group,
+                this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set."),
+                this.Ingredient ?? throw new NullReferenceException("Ingredient must not be null"),
+                this.Count
+            );
         }
     }
 }

--- a/Obsidian.API/Crafting/Builders/ShapedRecipeBuilder.cs
+++ b/Obsidian.API/Crafting/Builders/ShapedRecipeBuilder.cs
@@ -56,14 +56,14 @@ namespace Obsidian.API.Crafting.Builders
                 throw new InvalidOperationException("Keys cannot be empty.");
 
             return new ShapedRecipe
-            {
-                Name = this.Name ?? throw new NullReferenceException("Recipe must have a name"),
-                Type = CraftingType.CraftingShaped,
-                Group = this.Group,
-                Pattern = new ReadOnlyCollection<string>(new List<string>(this.pattern)),
-                Result = this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set."),
-                Key = new ReadOnlyDictionary<char, Ingredient>(new Dictionary<char, Ingredient>(this.key))
-            };
+            (
+                this.Name ?? throw new NullReferenceException("Recipe must have a name"),
+                CraftingType.CraftingShaped,
+                this.Group,
+                this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set."),
+                new ReadOnlyCollection<string>(new List<string>(this.pattern)),
+                new ReadOnlyDictionary<char, Ingredient>(new Dictionary<char, Ingredient>(this.key))
+            );
         }
 
         public ShapedRecipeBuilder WithName(string name)

--- a/Obsidian.API/Crafting/Builders/ShapelessRecipeBuilder.cs
+++ b/Obsidian.API/Crafting/Builders/ShapelessRecipeBuilder.cs
@@ -35,13 +35,13 @@ namespace Obsidian.API.Crafting.Builders
                 throw new InvalidOperationException("Ingredients must be filled with atleast 1 item.");
 
             return new ShapelessRecipe
-            {
-                Name = this.Name ?? throw new NullReferenceException("Recipe must have a name"),
-                Type = CraftingType.CraftingShapeless,
-                Group = this.Group,
-                Ingredients = new ReadOnlyCollection<Ingredient>(new List<Ingredient>(this.ingredients)),
-                Result = this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set.")
-            };
+            (
+                this.Name ?? throw new NullReferenceException("Recipe must have a name"),
+                CraftingType.CraftingShapeless,
+                this.Group,
+                this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set."),
+                new ReadOnlyCollection<Ingredient>(new List<Ingredient>(this.ingredients))
+            );
         }
 
         public ShapelessRecipeBuilder WithName(string name)

--- a/Obsidian.API/Crafting/Builders/SmeltingRecipeBuilder.cs
+++ b/Obsidian.API/Crafting/Builders/SmeltingRecipeBuilder.cs
@@ -78,22 +78,23 @@ namespace Obsidian.API.Crafting.Builders
                 SmeltingType.Default => CraftingType.Smelting,
                 SmeltingType.Blasting => CraftingType.Blasting,
                 SmeltingType.Smoking => CraftingType.Smoking,
-                SmeltingType.CampfireCooking => CraftingType.CampfireCooking
+                SmeltingType.CampfireCooking => CraftingType.CampfireCooking,
+                _ => throw new NotImplementedException()
             };
 
             if (this.Ingredient.Count <= 0)
                 throw new InvalidOperationException("Recipe must atleast have 1 item as an ingredient");
 
             return new SmeltingRecipe
-            {
-                Name = this.Name ?? throw new NullReferenceException("Recipe must have a name"),
-                Type = type,
+            (
+                this.Name ?? throw new NullReferenceException("Recipe must have a name"),
+                type,
                 Group = this.Group,
-                Ingredient = this.Ingredient,
-                Cookingtime = this.CookingTime,
-                Experience = this.Experience,
-                Result = this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set.")
-            };
+                this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set."),
+                this.Ingredient,
+                this.Experience,
+                this.CookingTime
+            );
         }
     }
 

--- a/Obsidian.API/Crafting/Builders/SmithingRecipeBuilder.cs
+++ b/Obsidian.API/Crafting/Builders/SmithingRecipeBuilder.cs
@@ -62,14 +62,14 @@ namespace Obsidian.API.Crafting.Builders
                 throw new InvalidOperationException("Sub ingredients must have atleast 1 item.");
 
             return new SmithingRecipe
-            {
-                Name = this.Name ?? throw new NullReferenceException("Recipe must have a name"),
-                Type = CraftingType.Smithing,
-                Group = this.Group,
-                Base = this.Base,
-                Addition = this.Addition,
-                Result = this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set.")
-            };
+            (
+                this.Name ?? throw new NullReferenceException("Recipe must have a name"),
+                CraftingType.Smithing,
+                this.Group,
+                this.Base,
+                this.Addition,
+                this.Result != null ? new Ingredient { this.Result } : throw new NullReferenceException("Result is not set.")
+            );
         }
     }
 }

--- a/Obsidian.API/Crafting/CuttingRecipe.cs
+++ b/Obsidian.API/Crafting/CuttingRecipe.cs
@@ -13,5 +13,15 @@
         public Ingredient Ingredient { get; set; }
 
         public int Count { get; set; }
+
+        public CuttingRecipe(string name, CraftingType type, string? group, Ingredient result, Ingredient ingredient, int count)
+        {
+            Name = name;
+            Type = type;
+            Group = group;
+            Result = result;
+            Ingredient = ingredient;
+            Count = count;
+        }
     }
 }

--- a/Obsidian.API/Crafting/IRecipe.cs
+++ b/Obsidian.API/Crafting/IRecipe.cs
@@ -6,7 +6,7 @@
 
         public CraftingType Type { get; set; }
 
-        public string Group { get; set; }
+        public string? Group { get; set; }
 
         public Ingredient Result { get; set; }
     }

--- a/Obsidian.API/Crafting/ShapedRecipe.cs
+++ b/Obsidian.API/Crafting/ShapedRecipe.cs
@@ -8,12 +8,22 @@ namespace Obsidian.API.Crafting
 
         public CraftingType Type { get; set; }
 
-        public string Group { get; set; }
+        public string? Group { get; set; }
 
         public Ingredient Result { get; set; }
 
         public IReadOnlyList<string> Pattern { get; set; }
 
         public IReadOnlyDictionary<char, Ingredient> Key { get; set; }
+
+        public ShapedRecipe(string name, CraftingType type, string? group, Ingredient result, IReadOnlyList<string> pattern, IReadOnlyDictionary<char, Ingredient> key)
+        {
+            Name = name;
+            Type = type;
+            Group = group;
+            Result = result;
+            Pattern = pattern;
+            Key = key;
+        }
     }
 }

--- a/Obsidian.API/Crafting/ShapelessRecipe.cs
+++ b/Obsidian.API/Crafting/ShapelessRecipe.cs
@@ -13,5 +13,14 @@ namespace Obsidian.API.Crafting
         public Ingredient Result { get; set; }
 
         public IReadOnlyList<Ingredient> Ingredients { get; set; }
+
+        public ShapelessRecipe(string name, CraftingType type, string? group, Ingredient result, IReadOnlyList<Ingredient> ingredients)
+        {
+            Name = name;
+            Type = type;
+            Group = group;
+            Result = result;
+            Ingredients = ingredients;
+        }
     }
 }

--- a/Obsidian.API/Crafting/SmeltingRecipe.cs
+++ b/Obsidian.API/Crafting/SmeltingRecipe.cs
@@ -15,5 +15,16 @@
         public float Experience { get; set; }
 
         public int Cookingtime { get; set; }
+
+        public SmeltingRecipe(string name, CraftingType type, string? group, Ingredient result, Ingredient ingredient, float experience, int cookingTime)
+        {
+            Name = name;
+            Type = type;
+            Group = group;
+            Result = result;
+            Ingredient = ingredient;
+            Experience = experience;
+            Cookingtime = cookingTime;
+        }
     }
 }

--- a/Obsidian.API/Crafting/SmithingRecipe.cs
+++ b/Obsidian.API/Crafting/SmithingRecipe.cs
@@ -14,13 +14,13 @@
 
         public Ingredient Addition { get; set; }
 
-        public SmithingRecipe(string name, CraftingType type, string? group, Ingredient result, Ingredient Base, Ingredient addition)
+        public SmithingRecipe(string name, CraftingType type, string? group, Ingredient result, Ingredient @base, Ingredient addition)
         {
             Name = name;
             Type = type;
             Group = group;
             Result = result;
-            this.Base = Base;
+            Base = @base;
             Addition = addition;
         }
     }

--- a/Obsidian.API/Crafting/SmithingRecipe.cs
+++ b/Obsidian.API/Crafting/SmithingRecipe.cs
@@ -13,5 +13,15 @@
         public Ingredient Base { get; set; }
 
         public Ingredient Addition { get; set; }
+
+        public SmithingRecipe(string name, CraftingType type, string? group, Ingredient result, Ingredient Base, Ingredient addition)
+        {
+            Name = name;
+            Type = type;
+            Group = group;
+            Result = result;
+            this.Base = Base;
+            Addition = addition;
+        }
     }
 }

--- a/Obsidian.API/Events/BaseMinecraftEventArgs.cs
+++ b/Obsidian.API/Events/BaseMinecraftEventArgs.cs
@@ -12,6 +12,7 @@
 
         /// <summary>
         /// Constructs a new instance of the <see cref="BaseMinecraftEventArgs"/> class.
+        /// </summary>
         /// <param name="server">The server that's handling this event.</param>
         internal BaseMinecraftEventArgs(IServer server)
         {

--- a/Obsidian.API/Noise/BitShiftInput.cs
+++ b/Obsidian.API/Noise/BitShiftInput.cs
@@ -27,7 +27,10 @@ namespace Obsidian.API.Noise
         /// <summary>
         /// ctor.
         /// </summary>
-        public BitShiftInput() : base(1) { }
+        public BitShiftInput(Module source0) : base(1) 
+        {
+            Source0 = source0;
+        }
 
         /// <summary>
         /// Retrieve noise value

--- a/Obsidian.API/Noise/Blend.cs
+++ b/Obsidian.API/Noise/Blend.cs
@@ -18,9 +18,9 @@ namespace Obsidian.API.Noise
         /// <summary>
         /// ctor.
         /// </summary>
-        public Blend() : base(1)
+        public Blend(Module source0) : base(1)
         {
-
+            Source0 = source0;
         }
 
         /// <summary>

--- a/Obsidian.API/Noise/Blur.cs
+++ b/Obsidian.API/Noise/Blur.cs
@@ -13,9 +13,9 @@ namespace Obsidian.API.Noise
         /// <summary>
         /// ctor.
         /// </summary>
-        public Blur() : base(1)
+        public Blur(Module source0) : base(1)
         {
-
+            Source0 = source0;
         }
 
         /// <summary>

--- a/Obsidian.API/Noise/Blur.cs
+++ b/Obsidian.API/Noise/Blur.cs
@@ -29,11 +29,10 @@ namespace Obsidian.API.Noise
         {
             // Bitshift the source module by 1 one so we can
             // "divide" each pixel into 4 quadrants
-            var shifted = new BitShiftInput
+            var shifted = new BitShiftInput(this.Source0)
             {
                 Amount = 1,
-                Left = false,
-                Source0 = this.Source0
+                Left = false
             };
 
             var self = shifted.GetValue(x, y, z);

--- a/Obsidian.API/Noise/FuncRunner.cs
+++ b/Obsidian.API/Noise/FuncRunner.cs
@@ -11,9 +11,10 @@ namespace Obsidian.API.Noise
 
         public int Utility { get; set; } = 0;
 
-        public FuncRunner() : base(1)
+        public FuncRunner(Module source0, Func<Module, double, double, double, double> conditionFunction) : base(1)
         {
-
+            Source0 = source0;
+            ConditionFunction = conditionFunction;
         }
 
         public override double GetValue(double x, double y, double z)

--- a/Obsidian.API/Noise/FuncSelector.cs
+++ b/Obsidian.API/Noise/FuncSelector.cs
@@ -26,9 +26,11 @@ namespace Obsidian.API.Noise
         /// <summary>
         /// Ctor.
         /// </summary>
-        public FuncSelector() : base(2)
+        public FuncSelector(Module source0, Module source1, Func<(double, double, double), int> conditionFunction) : base(2)
         {
-
+            Source0 = source0;
+            Source1 = source1;
+            ConditionFunction = conditionFunction;
         }
 
         /// <summary>

--- a/Obsidian.API/Noise/Interpolate.cs
+++ b/Obsidian.API/Noise/Interpolate.cs
@@ -7,9 +7,9 @@ namespace Obsidian.API.Noise
     {
         public Module Source0 { get; set; }
 
-        public Interpolate() : base(1)
+        public Interpolate(Module source0) : base(1)
         {
-
+            Source0 = source0;
         }
 
         public override double GetValue(double x, double y, double z)

--- a/Obsidian.API/Noise/Interpolate.cs
+++ b/Obsidian.API/Noise/Interpolate.cs
@@ -16,11 +16,10 @@ namespace Obsidian.API.Noise
         {
             // Bitshift the source module by 1 one so we can
             // "divide" each pixel into 4 quadrants
-            var shifted = new BitShiftInput
+            var shifted = new BitShiftInput(this.Source0)
             {
                 Amount = 1,
-                Left = false,
-                Source0 = this.Source0
+                Left = false
             };
 
             var center = shifted.GetValue(x, y, z);

--- a/Obsidian.API/Noise/Polariaze.cs
+++ b/Obsidian.API/Noise/Polariaze.cs
@@ -8,9 +8,9 @@ namespace Obsidian.API.Noise
 
         public double Center { get; set; } = 0;
 
-        public Polariaze() : base(1)
+        public Polariaze(Module source0) : base(1)
         {
-
+            Source0 = source0;
         }
 
         public override double GetValue(double x, double y, double z)

--- a/Obsidian.API/Noise/TerrainSelect.cs
+++ b/Obsidian.API/Noise/TerrainSelect.cs
@@ -9,9 +9,10 @@ namespace Obsidian.API.Noise
 
         public Module BiomeSelector { get; set; }
 
-        public TerrainSelect()
+        public TerrainSelect(Module biomeSelector)
         {
             Source1 = new Constant { ConstantValue = 0 };
+            BiomeSelector = biomeSelector;
         }
 
         public override double GetValue(double x, double y, double z)

--- a/Obsidian.API/Noise/TransitionMap.cs
+++ b/Obsidian.API/Noise/TransitionMap.cs
@@ -16,9 +16,10 @@ namespace Obsidian.API.Noise
         /// <summary>
         /// ctor.
         /// </summary>
-        public TransitionMap() : base(1)
+        public TransitionMap(Module source0, int distance) : base (1)
         {
-
+            Source0 = source0;
+            Distance = distance;
         }
 
         /// <summary>

--- a/Obsidian.API/Noise/Zoom.cs
+++ b/Obsidian.API/Noise/Zoom.cs
@@ -8,9 +8,10 @@ namespace Obsidian.API.Noise
 
         public double Amount { get; set; }
 
-        public Zoom() : base(1)
+        public Zoom(Module source0, double amount) : base(1)
         {
-
+            Source0 = source0;
+            Amount = amount;
         }
 
         public override double GetValue(double x, double y, double z)

--- a/Obsidian.API/Particles/ItemParticle.cs
+++ b/Obsidian.API/Particles/ItemParticle.cs
@@ -2,6 +2,11 @@
 {
     public class ItemParticle : IParticle
     {
+        public ItemParticle(ItemStack item)
+        {
+            Item = item;
+        }
+
         public int Id => 36;
 
         public ItemStack Item { get; set; }

--- a/Obsidian.API/Plugins/DependencyAttribute.cs
+++ b/Obsidian.API/Plugins/DependencyAttribute.cs
@@ -8,6 +8,12 @@ namespace Obsidian.API.Plugins
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public class DependencyAttribute : Attribute
     {
+        public DependencyAttribute(string minVersion, bool optional)
+        {
+            Optional = optional;
+            MinVersion = minVersion;
+        }
+
         /// <summary>
         /// Indicates whether the plugin can run without this dependency.
         /// </summary>

--- a/Obsidian.API/Plugins/PluginAttribute.cs
+++ b/Obsidian.API/Plugins/PluginAttribute.cs
@@ -8,6 +8,14 @@ namespace Obsidian.API.Plugins
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class PluginAttribute : Attribute
     {
+        /// <summary>
+        /// Plugin attribute constructor.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="authors"></param>
+        /// <param name="description"></param>
+        /// <param name="projectUrl"></param>
         public PluginAttribute(string name, string version, string authors, string description, string projectUrl)
         {
             Name = name;
@@ -20,26 +28,26 @@ namespace Obsidian.API.Plugins
         /// <summary>
         /// Name of the plugin.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>
         /// Version of the plugin. The string should contain the major, minor, <i>[build]</i>, and <i>[revision]</i> numbers, split by a period character ('.').
         /// </summary>
-        public string Version { get; set; }
+        public string Version { get; }
 
         /// <summary>
         /// Name(s) of the plugin's author(s).
         /// </summary>
-        public string Authors { get; set; }
+        public string Authors { get; }
 
         /// <summary>
         /// Description of the plugin.
         /// </summary>
-        public string Description { get; set; }
+        public string Description { get; }
 
         /// <summary>
         /// URL address of where the plugin is hosted.
         /// </summary>
-        public string ProjectUrl { get; set; }
+        public string ProjectUrl { get; }
     }
 }

--- a/Obsidian.API/Plugins/PluginAttribute.cs
+++ b/Obsidian.API/Plugins/PluginAttribute.cs
@@ -25,21 +25,21 @@ namespace Obsidian.API.Plugins
         /// <summary>
         /// Version of the plugin. The string should contain the major, minor, <i>[build]</i>, and <i>[revision]</i> numbers, split by a period character ('.').
         /// </summary>
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         /// <summary>
         /// Name(s) of the plugin's author(s).
         /// </summary>
-        public string Authors { get; set; }
+        public string? Authors { get; set; }
 
         /// <summary>
         /// Description of the plugin.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// URL address of where the plugin is hosted.
         /// </summary>
-        public string ProjectUrl { get; set; }
+        public string? ProjectUrl { get; set; }
     }
 }

--- a/Obsidian.API/Plugins/PluginAttribute.cs
+++ b/Obsidian.API/Plugins/PluginAttribute.cs
@@ -8,6 +8,15 @@ namespace Obsidian.API.Plugins
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class PluginAttribute : Attribute
     {
+        public PluginAttribute(string name, string version, string authors, string description, string projectUrl)
+        {
+            Name = name;
+            Version = version;
+            Authors = authors;
+            Description = description;
+            ProjectUrl = projectUrl;
+        }
+
         /// <summary>
         /// Name of the plugin.
         /// </summary>

--- a/Obsidian.API/Plugins/PluginAttribute.cs
+++ b/Obsidian.API/Plugins/PluginAttribute.cs
@@ -12,17 +12,9 @@ namespace Obsidian.API.Plugins
         /// Plugin attribute constructor.
         /// </summary>
         /// <param name="name"></param>
-        /// <param name="version"></param>
-        /// <param name="authors"></param>
-        /// <param name="description"></param>
-        /// <param name="projectUrl"></param>
-        public PluginAttribute(string name, string version, string authors, string description, string projectUrl)
+        public PluginAttribute(string name)
         {
             Name = name;
-            Version = version;
-            Authors = authors;
-            Description = description;
-            ProjectUrl = projectUrl;
         }
 
         /// <summary>
@@ -33,21 +25,21 @@ namespace Obsidian.API.Plugins
         /// <summary>
         /// Version of the plugin. The string should contain the major, minor, <i>[build]</i>, and <i>[revision]</i> numbers, split by a period character ('.').
         /// </summary>
-        public string Version { get; }
+        public string Version { get; set; }
 
         /// <summary>
         /// Name(s) of the plugin's author(s).
         /// </summary>
-        public string Authors { get; }
+        public string Authors { get; set; }
 
         /// <summary>
         /// Description of the plugin.
         /// </summary>
-        public string Description { get; }
+        public string Description { get; set; }
 
         /// <summary>
         /// URL address of where the plugin is hosted.
         /// </summary>
-        public string ProjectUrl { get; }
+        public string ProjectUrl { get; set; }
     }
 }

--- a/Obsidian.API/Plugins/PluginBase.cs
+++ b/Obsidian.API/Plugins/PluginBase.cs
@@ -20,6 +20,18 @@ namespace Obsidian.API.Plugins
 
         private Type typeCache;
 
+        public PluginBase(Type TypeCache)
+        {
+            typeCache = TypeCache;
+        }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public PluginBase()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+
+        }
+
         public void RegisterCommand(Action action)
         {
             registerSingleCommand(action);
@@ -31,7 +43,7 @@ namespace Obsidian.API.Plugins
         public object? Invoke(string methodName, params object[] args)
         {
             var method = GetMethod(methodName, args);
-            return method.Invoke(this, args);
+            return method?.Invoke(this, args);
         }
 
         /// <summary>
@@ -46,12 +58,12 @@ namespace Obsidian.API.Plugins
                 args = args.Take(parameterCount).ToArray();
             try
             {
-                var result = method.Invoke(this, args);
-                if (result is Task task)
-                    return task;
-                else if (result is ValueTask valueTask)
-                    return valueTask.AsTask();
-                return Task.FromResult(result);
+                    var result = method?.Invoke(this, args);
+                    if (result is Task task)
+                        return task;
+                    else if (result is ValueTask valueTask)
+                        return valueTask.AsTask();
+                    return Task.FromResult(result);
             }
             catch (Exception e)
             {
@@ -66,7 +78,7 @@ namespace Obsidian.API.Plugins
         public Task InvokeAsync(string methodName, params object[] args)
         {
             var method = GetMethod(methodName, args);
-            var result = method.Invoke(this, args);
+            var result = method?.Invoke(this, args);
             if (result is Task task)
                 return task;
             else if (result is ValueTask valueTask)
@@ -80,7 +92,7 @@ namespace Obsidian.API.Plugins
         public T? Invoke<T>(string methodName, params object[] args)
         {
             var method = GetMethod(methodName, args);
-            return (T?)method.Invoke(this, args);
+            return (T?)method?.Invoke(this, args);
         }
 
         /// <summary>
@@ -90,7 +102,7 @@ namespace Obsidian.API.Plugins
         public Task<T?> InvokeAsync<T>(string methodName, params object[] args)
         {
             var method = GetMethod(methodName, args);
-            var result = method.Invoke(this, args);
+            var result = method?.Invoke(this, args);
             if (result is Task<T?> task)
                 return task;
             else if (result is ValueTask<T?> valueTask)
@@ -137,7 +149,7 @@ namespace Obsidian.API.Plugins
                 args = args.Take(parameterCount).ToArray();
             try
             {
-                return method.Invoke(this, args);
+                return method?.Invoke(this, args);
             }
             catch (Exception e)
             {
@@ -175,7 +187,7 @@ namespace Obsidian.API.Plugins
             }
         }
 
-        private MethodInfo GetMethod(string methodName, object[] args)
+        private MethodInfo? GetMethod(string methodName, object[] args)
         {
             args ??= Array.Empty<object>();
             var types = new Type[args.Length];

--- a/Obsidian.API/Plugins/PluginBase.cs
+++ b/Obsidian.API/Plugins/PluginBase.cs
@@ -51,12 +51,12 @@ namespace Obsidian.API.Plugins
                 args = args.Take(parameterCount).ToArray();
             try
             {
-                    var result = method?.Invoke(this, args);
-                    if (result is Task task)
-                        return task;
-                    else if (result is ValueTask valueTask)
-                        return valueTask.AsTask();
-                    return Task.FromResult(result);
+                var result = method?.Invoke(this, args);
+                if (result is Task task)
+                    return task;
+                else if (result is ValueTask valueTask)
+                    return valueTask.AsTask();
+                return Task.FromResult(result);
             }
             catch (Exception e)
             {
@@ -230,6 +230,7 @@ namespace Obsidian.API.Plugins
                         break;
                     }
                 }
+
                 if (match)
                     return (method, parameters.Length);
             }

--- a/Obsidian.API/Plugins/PluginBase.cs
+++ b/Obsidian.API/Plugins/PluginBase.cs
@@ -20,16 +20,9 @@ namespace Obsidian.API.Plugins
 
         private Type typeCache;
 
-        public PluginBase(Type TypeCache)
-        {
-            typeCache = TypeCache;
-        }
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public PluginBase()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
-
+            typeCache ??= GetType();
         }
 
         public void RegisterCommand(Action action)

--- a/Obsidian.API/Plugins/PluginWrapper.cs
+++ b/Obsidian.API/Plugins/PluginWrapper.cs
@@ -7,9 +7,16 @@ namespace Obsidian.API.Plugins
     /// </summary>
     public abstract class PluginWrapper
     {
-        internal PluginBase plugin;
+        internal PluginBase Plugin;
 
+        public PluginWrapper(PluginBase plugin)
+        {
+            Plugin = plugin;
+        }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public PluginWrapper()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
 
         }
@@ -17,17 +24,17 @@ namespace Obsidian.API.Plugins
         /// <summary>
         /// Invokes a method in the class. For repeated calls use <see cref="GetMethod{T}(string, Type[])">GetMethod</see> or make a plugin wrapper.
         /// </summary>
-        public object Invoke(string methodName, params object[] args)
+        public object? Invoke(string methodName, params object[] args)
         {
-            return plugin.Invoke(methodName, args);
+            return Plugin.Invoke(methodName, args);
         }
 
         /// <summary>
         /// Invokes a method in the class. For repeated calls use <see cref="GetMethod{T}(string, Type[])">GetMethod</see> or make a plugin wrapper.
         /// </summary>
-        public T Invoke<T>(string methodName, params object[] args)
+        public T? Invoke<T>(string methodName, params object[] args)
         {
-            return plugin.Invoke<T>(methodName, args);
+            return Plugin.Invoke<T>(methodName, args);
         }
 
         /// <summary>
@@ -35,7 +42,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public T GetMethod<T>(string methodName, params Type[] parameterTypes) where T : Delegate
         {
-            return plugin.GetMethod<T>(methodName, parameterTypes);
+            return Plugin.GetMethod<T>(methodName, parameterTypes);
         }
 
         /// <summary>
@@ -43,7 +50,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public Func<T> GetPropertyGetter<T>(string propertyName)
         {
-            return plugin.GetPropertyGetter<T>(propertyName);
+            return Plugin.GetPropertyGetter<T>(propertyName);
         }
 
         /// <summary>
@@ -51,7 +58,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public Action<T> GetPropertySetter<T>(string propertyName)
         {
-            return plugin.GetPropertySetter<T>(propertyName);
+            return Plugin.GetPropertySetter<T>(propertyName);
         }
     }
 }

--- a/Obsidian.API/Plugins/PluginWrapper.cs
+++ b/Obsidian.API/Plugins/PluginWrapper.cs
@@ -7,11 +7,11 @@ namespace Obsidian.API.Plugins
     /// </summary>
     public abstract class PluginWrapper
     {
-        internal PluginBase Plugin;
+        internal PluginBase plugin;
 
         public PluginWrapper(PluginBase plugin)
         {
-            Plugin = plugin;
+            this.plugin = plugin;
         }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -26,7 +26,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public object? Invoke(string methodName, params object[] args)
         {
-            return Plugin.Invoke(methodName, args);
+            return plugin.Invoke(methodName, args);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public T? Invoke<T>(string methodName, params object[] args)
         {
-            return Plugin.Invoke<T>(methodName, args);
+            return plugin.Invoke<T>(methodName, args);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public T GetMethod<T>(string methodName, params Type[] parameterTypes) where T : Delegate
         {
-            return Plugin.GetMethod<T>(methodName, parameterTypes);
+            return plugin.GetMethod<T>(methodName, parameterTypes);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public Func<T> GetPropertyGetter<T>(string propertyName)
         {
-            return Plugin.GetPropertyGetter<T>(propertyName);
+            return plugin.GetPropertyGetter<T>(propertyName);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Obsidian.API.Plugins
         /// </summary>
         public Action<T> GetPropertySetter<T>(string propertyName)
         {
-            return Plugin.GetPropertySetter<T>(propertyName);
+            return plugin.GetPropertySetter<T>(propertyName);
         }
     }
 }

--- a/Obsidian.API/Plugins/Services/IDiagnoser.cs
+++ b/Obsidian.API/Plugins/Services/IDiagnoser.cs
@@ -31,7 +31,7 @@ namespace Obsidian.API.Plugins.Services
         /// <param name="createWindow">Indicates whether to start the process in a new window.</param>
         /// <param name="useShell">Indicates whether to use the operating system shell to start the process.</param>
         /// <returns>A new <see cref="IProcess"/> that is associated with the process resource, or null if no process resource is started. </returns>
-        public IProcess StartProcess(string fileName, string arguments = null, bool createWindow = true, bool useShell = false);
+        public IProcess StartProcess(string fileName, string arguments = "", bool createWindow = true, bool useShell = false);
 
         /// <summary>
         /// Returns a new instance of <see cref="IStopwatch"/>.

--- a/Obsidian.API/Plugins/Services/IDiagnoser.cs
+++ b/Obsidian.API/Plugins/Services/IDiagnoser.cs
@@ -31,7 +31,7 @@ namespace Obsidian.API.Plugins.Services
         /// <param name="createWindow">Indicates whether to start the process in a new window.</param>
         /// <param name="useShell">Indicates whether to use the operating system shell to start the process.</param>
         /// <returns>A new <see cref="IProcess"/> that is associated with the process resource, or null if no process resource is started. </returns>
-        public IProcess StartProcess(string fileName, string arguments = "", bool createWindow = true, bool useShell = false);
+        public IProcess StartProcess(string fileName, string? arguments = null, bool createWindow = true, bool useShell = false);
 
         /// <summary>
         /// Returns a new instance of <see cref="IStopwatch"/>.

--- a/Obsidian.API/Plugins/Services/IFileReader.cs
+++ b/Obsidian.API/Plugins/Services/IFileReader.cs
@@ -64,9 +64,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Directory.GetFiles(path);
         }
@@ -81,9 +94,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Directory.GetDirectories(path);
         }

--- a/Obsidian.API/Plugins/Services/IFileWriter.cs
+++ b/Obsidian.API/Plugins/Services/IFileWriter.cs
@@ -76,9 +76,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             File.Create(path).Close();
         }
@@ -92,14 +105,30 @@ namespace Obsidian.API.Plugins.Services
             if (!IsUsable)
                 throw new SecurityException(SecurityExceptionMessage);
 
-            var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(sourceFileName)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
-            if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
-                sourceFileName = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), sourceFileName);
+            string workingDirectory = GetWorkingDirectory();
+            var fullPath1 = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
+            var fullPath2 = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
 
-            if (!Path.GetDirectoryName(Path.GetFullPath(destinationFileName)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
+            if (fullPath1 == null || fullPath2 == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath1.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
+            if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
+                sourceFileName = Path.Combine(fullPathToCombine, sourceFileName);
+
+            workingDirectory = GetWorkingDirectory();
+
+            if (!fullPath2.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(destinationFileName))
-                destinationFileName = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), destinationFileName);
+                destinationFileName = Path.Combine(fullPathToCombine, destinationFileName);
 
             File.Copy(sourceFileName, destinationFileName, overwrite: true);
         }
@@ -114,13 +143,29 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(sourceFileName)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
-            if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
-                sourceFileName = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), sourceFileName);
+            var fullPath1 = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
+            var fullPath2 = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
 
-            if (!Path.GetDirectoryName(Path.GetFullPath(destinationFileName)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
+            if (fullPath1 == null || fullPath2 == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath1.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
+            if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
+                sourceFileName = Path.Combine(fullPathToCombine, sourceFileName);
+
+            workingDirectory = GetWorkingDirectory();
+
+            if (!fullPath2.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(destinationFileName))
-                destinationFileName = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), destinationFileName);
+                destinationFileName = Path.Combine(fullPathToCombine, destinationFileName);
             
             File.Move(sourceFileName, destinationFileName);
         }
@@ -135,9 +180,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             File.Delete(path);
         }
@@ -152,9 +210,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             Directory.CreateDirectory(path);
         }
@@ -169,9 +240,22 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             Directory.Delete(path, recursive: true);
         }

--- a/Obsidian.API/Plugins/Services/IFileWriter.cs
+++ b/Obsidian.API/Plugins/Services/IFileWriter.cs
@@ -106,11 +106,11 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             string workingDirectory = GetWorkingDirectory();
-            var fullPath1 = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
-            var fullPath2 = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
+            var sourceFilePath = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
+            var destinationFilePath = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
             var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
 
-            if (fullPath1 == null || fullPath2 == null)
+            if (sourceFilePath == null || destinationFilePath == null)
             {
                 throw new DirectoryNotFoundException();
             }
@@ -120,13 +120,13 @@ namespace Obsidian.API.Plugins.Services
                 throw new DirectoryNotFoundException();
             }
 
-            if (!fullPath1.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
+            if (!sourceFilePath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
                 sourceFileName = Path.Combine(fullPathToCombine, sourceFileName);
 
             workingDirectory = GetWorkingDirectory();
 
-            if (!fullPath2.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
+            if (!destinationFilePath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(destinationFileName))
                 destinationFileName = Path.Combine(fullPathToCombine, destinationFileName);
 
@@ -143,11 +143,11 @@ namespace Obsidian.API.Plugins.Services
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            var fullPath1 = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
-            var fullPath2 = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
+            var sourceFilePath = Path.GetDirectoryName(Path.GetFullPath(sourceFileName));
+            var destinationFilePath = Path.GetDirectoryName(Path.GetFullPath(destinationFileName));
             var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
 
-            if (fullPath1 == null || fullPath2 == null)
+            if (sourceFilePath == null || destinationFilePath == null)
             {
                 throw new DirectoryNotFoundException();
             }
@@ -157,13 +157,13 @@ namespace Obsidian.API.Plugins.Services
                 throw new DirectoryNotFoundException();
             }
 
-            if (!fullPath1.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
+            if (!sourceFilePath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(sourceFileName)) throw new UnauthorizedAccessException(sourceFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(sourceFileName))
                 sourceFileName = Path.Combine(fullPathToCombine, sourceFileName);
 
             workingDirectory = GetWorkingDirectory();
 
-            if (!fullPath2.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
+            if (!destinationFilePath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(destinationFileName)) throw new UnauthorizedAccessException(destinationFileName);
             if (workingDirectory != null && !Path.IsPathFullyQualified(destinationFileName))
                 destinationFileName = Path.Combine(fullPathToCombine, destinationFileName);
             

--- a/Obsidian.API/Plugins/Services/ILogger.cs
+++ b/Obsidian.API/Plugins/Services/ILogger.cs
@@ -57,10 +57,6 @@ namespace Obsidian.API.Plugins.Services
             {
                 Log(exception.StackTrace);
             }
-            else
-            {
-                Log("No stack trace...");
-            }
         }
     }
 }

--- a/Obsidian.API/Plugins/Services/ILogger.cs
+++ b/Obsidian.API/Plugins/Services/ILogger.cs
@@ -53,7 +53,14 @@ namespace Obsidian.API.Plugins.Services
         public void LogTrace<T>(T exception) where T : Exception
         {
             Log($"{nameof(T)}: {exception.Message}");
-            Log(exception.StackTrace);
+            if (exception.StackTrace != null)
+            {
+                Log(exception.StackTrace);
+            }
+            else
+            {
+                Log("No stack trace...");
+            }
         }
     }
 }

--- a/Obsidian.API/Plugins/Services/IO/IFileService.cs
+++ b/Obsidian.API/Plugins/Services/IO/IFileService.cs
@@ -19,10 +19,23 @@ namespace Obsidian.API.Plugins.Services.IO
             if (!IsUsable)
                 throw new SecurityException(SecurityExceptionMessage);
 
-            var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            string workingDirectory = GetWorkingDirectory();
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return File.Exists(path);
         }
@@ -37,9 +50,22 @@ namespace Obsidian.API.Plugins.Services.IO
                 throw new SecurityException(SecurityExceptionMessage);
 
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Directory.Exists(path);
         }
@@ -49,13 +75,26 @@ namespace Obsidian.API.Plugins.Services.IO
         /// </summary>
         public string CombinePath(params string[] paths)
         {
-            var workingDirectory = GetWorkingDirectory();
+            string workingDirectory = GetWorkingDirectory();
             for (int i = 0; i < paths.Length; i++)
             {
                 var path = paths[i];
-                if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+                var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+                var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+                if (fullPath == null)
+                {
+                    throw new DirectoryNotFoundException();
+                }
+
+                if (fullPathToCombine == null)
+                {
+                    throw new DirectoryNotFoundException();
+                }
+
+                if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
                 if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                    paths[i] = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                    paths[i] = Path.Combine(fullPathToCombine, path);;
             }
 
             return Path.Combine(paths);
@@ -67,9 +106,22 @@ namespace Obsidian.API.Plugins.Services.IO
         public string GetExtension(string path)
         {
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Path.GetExtension(path);
         }
@@ -80,9 +132,22 @@ namespace Obsidian.API.Plugins.Services.IO
         public string GetFileName(string path)
         {
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Path.GetFileName(path);
         }
@@ -93,9 +158,22 @@ namespace Obsidian.API.Plugins.Services.IO
         public string GetFileNameWithoutExtension(string path)
         {
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Path.GetFileNameWithoutExtension(path);
         }
@@ -106,9 +184,22 @@ namespace Obsidian.API.Plugins.Services.IO
         public string GetFullPath(string path)
         {
             var workingDirectory = GetWorkingDirectory();
-            if (!Path.GetDirectoryName(Path.GetFullPath(path)).StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
+            var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
+            var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
+
+            if (fullPath == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (fullPathToCombine == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            if (!fullPath.StartsWith(workingDirectory, true, null) && Path.IsPathFullyQualified(path)) throw new UnauthorizedAccessException(path);
             if (workingDirectory != null && !Path.IsPathFullyQualified(path))
-                path = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(workingDirectory)), path);
+                path = Path.Combine(fullPathToCombine, path);
 
             return Path.GetFullPath(path);
         }

--- a/Obsidian.API/Plugins/Services/IO/IFileService.cs
+++ b/Obsidian.API/Plugins/Services/IO/IFileService.cs
@@ -75,10 +75,10 @@ namespace Obsidian.API.Plugins.Services.IO
         /// </summary>
         public string CombinePath(params string[] paths)
         {
-            string workingDirectory = GetWorkingDirectory();
             for (int i = 0; i < paths.Length; i++)
             {
                 var path = paths[i];
+                var workingDirectory = GetWorkingDirectory();
                 var fullPath = Path.GetDirectoryName(Path.GetFullPath(path));
                 var fullPathToCombine = Path.GetDirectoryName(Path.GetFullPath(workingDirectory));
 

--- a/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
+++ b/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
@@ -19,13 +19,10 @@ namespace Obsidian.API
 
         public override Task<bool> RunChecksAsync(CommandContext context)
         {
-            if (context.Player == null)
-            {
-                throw new Exception("Player not found");
-            }
-
             if(context.Sender.Issuer == CommandIssuers.Console)
                 return Task.FromResult(true);
+            if (context.Player == null)
+                return Task.FromResult(false);
             if (this.op && context.Player.IsOperator)
                 return Task.FromResult(true);
 

--- a/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
+++ b/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
@@ -19,6 +19,11 @@ namespace Obsidian.API
 
         public override Task<bool> RunChecksAsync(CommandContext context)
         {
+            if (context.Player == null)
+            {
+                throw new Exception("Player not found");
+            }
+
             if(context.Sender.Issuer == CommandIssuers.Console)
                 return Task.FromResult(true);
             if (this.op && context.Player.IsOperator)

--- a/Obsidian.API/_Interfaces/ILiving.cs
+++ b/Obsidian.API/_Interfaces/ILiving.cs
@@ -4,7 +4,7 @@
     {
         public LivingBitMask LivingBitMask { get; set; }
 
-        public float Health { get; set; }
+        public new float Health { get; set; }
 
         public uint ActiveEffectColor { get; }
 

--- a/Obsidian.API/_Interfaces/ILiving.cs
+++ b/Obsidian.API/_Interfaces/ILiving.cs
@@ -4,7 +4,7 @@
     {
         public LivingBitMask LivingBitMask { get; set; }
 
-        public new float Health { get; set; }
+        public float Health { get; set; }
 
         public uint ActiveEffectColor { get; }
 

--- a/Obsidian.API/_Interfaces/IPlayer.cs
+++ b/Obsidian.API/_Interfaces/IPlayer.cs
@@ -10,7 +10,7 @@ namespace Obsidian.API
 
         public string Username { get; }
 
-        public Guid Uuid { get; }
+        public new Guid Uuid { get; }
         public bool IsOperator { get; }
 
         public Gamemode Gamemode { get; set; }

--- a/Obsidian.API/_Interfaces/IPlayer.cs
+++ b/Obsidian.API/_Interfaces/IPlayer.cs
@@ -10,7 +10,7 @@ namespace Obsidian.API
 
         public string Username { get; }
 
-        public new Guid Uuid { get; }
+        public Guid Uuid { get; }
         public bool IsOperator { get; }
 
         public Gamemode Gamemode { get; set; }

--- a/Obsidian.API/_Types/Advancements/Advancement.cs
+++ b/Obsidian.API/_Types/Advancements/Advancement.cs
@@ -4,6 +4,15 @@ namespace Obsidian.API.Advancements
 {
     public sealed class Advancement
     {
+        public Advancement(string identifier, string parent, AdvancementDisplay? display, AdvancementReward? reward, List<Criteria> criteria)
+        {
+            Identifier = identifier;
+            Parent = parent;
+            Display = display;
+            Reward = reward;
+            Criteria = criteria;
+        }
+
         /// <summary>
         /// The identifier of the advancement.
         /// If a valid identifier is not detected this advancement will register with the obsidian namespace.

--- a/Obsidian.API/_Types/Advancements/AdvancementDisplay.cs
+++ b/Obsidian.API/_Types/Advancements/AdvancementDisplay.cs
@@ -4,6 +4,18 @@ namespace Obsidian.API.Advancements
 {
     public sealed class AdvancementDisplay
     {
+        public AdvancementDisplay(ChatMessage title, ChatMessage description, Item icon, AdvancementFrameType advancementFrameType, AdvancementFlags flags, string backgroundTexture, float xCoord, float yCoord)
+        {
+            Title = title;
+            Description = description;
+            Icon = icon;
+            AdvancementFrameType = advancementFrameType;
+            Flags = flags;
+            BackgroundTexture = backgroundTexture;
+            XCoord = xCoord;
+            YCoord = yCoord;
+        }
+
         public ChatMessage Title { get; init; }
 
         public ChatMessage Description { get; init; }

--- a/Obsidian.API/_Types/Advancements/AdvancementReward.cs
+++ b/Obsidian.API/_Types/Advancements/AdvancementReward.cs
@@ -4,6 +4,13 @@ namespace Obsidian.API.Advancements
 {
     public sealed class AdvancementReward
     {
+        public AdvancementReward(int? experience, List<string> loot, List<string> recipes)
+        {
+            Experience = experience;
+            Loot = loot;
+            Recipes = recipes;
+        }
+
         public int? Experience { get; init; }
 
         public List<string> Loot { get; init; }

--- a/Obsidian.API/_Types/Block.cs
+++ b/Obsidian.API/_Types/Block.cs
@@ -139,7 +139,7 @@ namespace Obsidian.API
             return stateToMatch[baseId].numeric == (int)material;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is Block block) && block.StateId == StateId;
         }

--- a/Obsidian.API/_Types/ChatMessage.cs
+++ b/Obsidian.API/_Types/ChatMessage.cs
@@ -6,6 +6,28 @@ namespace Obsidian.API
 {
     public class ChatMessage
     {
+        public ChatMessage(string text, HexColor color, bool bold, bool italic, bool underlined, bool strikethrough, bool obfuscated, string insertion, ClickComponent clickEvent, HoverComponent hoverEvent, List<ChatMessage> extra)
+        {
+            Text = text;
+            Color = color;
+            Bold = bold;
+            Italic = italic;
+            Underlined = underlined;
+            Strikethrough = strikethrough;
+            Obfuscated = obfuscated;
+            Insertion = insertion;
+            ClickEvent = clickEvent;
+            HoverEvent = hoverEvent;
+            Extra = extra;
+        }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public ChatMessage()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+
+        }
+
         public string Text { get; set; }
 
         public HexColor Color { get; set; }

--- a/Obsidian.API/_Types/ChatMessage.cs
+++ b/Obsidian.API/_Types/ChatMessage.cs
@@ -6,28 +6,6 @@ namespace Obsidian.API
 {
     public class ChatMessage
     {
-        public ChatMessage(string text, HexColor color, bool bold, bool italic, bool underlined, bool strikethrough, bool obfuscated, string insertion, ClickComponent clickEvent, HoverComponent hoverEvent, List<ChatMessage> extra)
-        {
-            Text = text;
-            Color = color;
-            Bold = bold;
-            Italic = italic;
-            Underlined = underlined;
-            Strikethrough = strikethrough;
-            Obfuscated = obfuscated;
-            Insertion = insertion;
-            ClickEvent = clickEvent;
-            HoverEvent = hoverEvent;
-            Extra = extra;
-        }
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public ChatMessage()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-
-        }
-
         public string Text { get; set; }
 
         public HexColor Color { get; set; }

--- a/Obsidian.API/_Types/ClickComponent.cs
+++ b/Obsidian.API/_Types/ClickComponent.cs
@@ -7,5 +7,12 @@
         public string Value { get; set; }
 
         public string Translate { get; set; }
+
+        public ClickComponent(EClickAction action, string value, string translate)
+        {
+            Action = action;
+            Value = value;
+            Translate = translate;
+        }
     }
 }

--- a/Obsidian.API/_Types/ClickComponent.cs
+++ b/Obsidian.API/_Types/ClickComponent.cs
@@ -8,7 +8,7 @@
 
         public string Translate { get; set; }
 
-        public ClickComponent(EClickAction action, string value, string translate)
+        public ClickComponent(EClickAction action, string value, string translate = "")
         {
             Action = action;
             Value = value;

--- a/Obsidian.API/_Types/HoverComponent.cs
+++ b/Obsidian.API/_Types/HoverComponent.cs
@@ -8,7 +8,7 @@
 
         public string Translate { get; set; }
 
-        public HoverComponent(EHoverAction action, object contents, string translate)
+        public HoverComponent(EHoverAction action, object contents, string translate = "")
         {
             Action = action;
             Contents = contents;

--- a/Obsidian.API/_Types/HoverComponent.cs
+++ b/Obsidian.API/_Types/HoverComponent.cs
@@ -7,5 +7,12 @@
         public object Contents { get; set; }
 
         public string Translate { get; set; }
+
+        public HoverComponent(EHoverAction action, object contents, string translate)
+        {
+            Action = action;
+            Contents = contents;
+            Translate = translate;
+        }
     }
 }

--- a/Obsidian.API/_Types/Inventory/ItemMeta.cs
+++ b/Obsidian.API/_Types/Inventory/ItemMeta.cs
@@ -30,7 +30,7 @@ namespace Obsidian.API
             (this.Slot, this.CustomModelData, this.Name, this.RepairAmount, this.Durability, this.Unbreakable, this.Enchantments, this.StoredEnchantments, this.CanDestroy, this.Lore) ==
             (other.Slot, other.CustomModelData, other.Name, other.RepairAmount, other.Durability, other.Unbreakable, other.Enchantments, other.StoredEnchantments, other.CanDestroy, other.Lore);
 
-        public override bool Equals(object obj) => obj is ItemMeta meta && Equals(meta);
+        public override bool Equals(object? obj) => obj is ItemMeta meta && Equals(meta);
 
         public static bool operator ==(ItemMeta left, ItemMeta right) => left.Equals(right);
 

--- a/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
+++ b/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
@@ -8,7 +8,7 @@ namespace Obsidian.API
         internal byte Slot { get; set; }
 
         internal int CustomModelData { get; set; }
-        public ChatMessage Name { get; internal set; }
+        public ChatMessage? Name { get; internal set; }
 
         public int Durability { get; internal set; }
 
@@ -28,13 +28,11 @@ namespace Obsidian.API
 
         private readonly List<ChatMessage> lore = new List<ChatMessage>();
 
-        public ItemMetaBuilder(string name = "")
+        public ItemMetaBuilder()
         {
             this.Enchantments = new ReadOnlyDictionary<EnchantmentType, Enchantment>(this.enchantments);
             this.StoredEnchantments = new ReadOnlyDictionary<EnchantmentType, Enchantment>(this.storedEnchantments);
-            this.Name = name;
             this.CanDestroy = new ReadOnlyCollection<string>(this.canDestroy);
-
             this.Lore = new ReadOnlyCollection<ChatMessage>(this.lore);
         }
 

--- a/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
+++ b/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
@@ -28,11 +28,11 @@ namespace Obsidian.API
 
         private readonly List<ChatMessage> lore = new List<ChatMessage>();
 
-        public ItemMetaBuilder()
+        public ItemMetaBuilder(string name = "")
         {
             this.Enchantments = new ReadOnlyDictionary<EnchantmentType, Enchantment>(this.enchantments);
             this.StoredEnchantments = new ReadOnlyDictionary<EnchantmentType, Enchantment>(this.storedEnchantments);
-
+            this.Name = name;
             this.CanDestroy = new ReadOnlyCollection<string>(this.canDestroy);
 
             this.Lore = new ReadOnlyCollection<ChatMessage>(this.lore);

--- a/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
+++ b/Obsidian.API/_Types/Inventory/ItemMetaBuilder.cs
@@ -8,7 +8,7 @@ namespace Obsidian.API
         internal byte Slot { get; set; }
 
         internal int CustomModelData { get; set; }
-        public ChatMessage? Name { get; internal set; }
+        public ChatMessage Name { get; internal set; }
 
         public int Durability { get; internal set; }
 

--- a/Obsidian.API/_Types/Inventory/ItemStack.cs
+++ b/Obsidian.API/_Types/Inventory/ItemStack.cs
@@ -57,7 +57,7 @@ namespace Obsidian.API
             return item;
         }
 
-        public bool Equals(ItemStack other) => (this.Type, this.ItemMeta) == (other?.Type, other?.ItemMeta);
+        public bool Equals(ItemStack other) => (this.Type, this.ItemMeta) == (other.Type, other.ItemMeta);
 
         public override bool Equals(object? obj) => obj is ItemStack itemStack && Equals(itemStack);
 

--- a/Obsidian.API/_Types/Inventory/ItemStack.cs
+++ b/Obsidian.API/_Types/Inventory/ItemStack.cs
@@ -57,7 +57,7 @@ namespace Obsidian.API
             return item;
         }
 
-        public bool Equals(ItemStack other) => (this.Type, this.ItemMeta) == (other.Type, other.ItemMeta);
+        public bool Equals(ItemStack? other) => (this.Type, this.ItemMeta) == (other?.Type, other?.ItemMeta);
 
         public override bool Equals(object? obj) => obj is ItemStack itemStack && Equals(itemStack);
 

--- a/Obsidian.API/_Types/Score.cs
+++ b/Obsidian.API/_Types/Score.cs
@@ -2,6 +2,12 @@
 {
     public sealed class Score
     {
+        public Score(string displayText, int value)
+        {
+            DisplayText = displayText;
+            Value = value;
+        }
+
         public string DisplayText { get; internal set; }
 
         public int Value { get; internal set; }

--- a/Obsidian.API/_Types/ScoreboardObjective.cs
+++ b/Obsidian.API/_Types/ScoreboardObjective.cs
@@ -2,6 +2,13 @@
 {
     public sealed class ScoreboardObjective
     {
+        public ScoreboardObjective(string objectiveName, ChatMessage value, DisplayType displayType)
+        {
+            ObjectiveName = objectiveName;
+            Value = value;
+            DisplayType = displayType;
+        }
+
         public string ObjectiveName { get; internal set; }
 
         public ChatMessage Value { get; internal set; }

--- a/Obsidian.Tests/Noise.cs
+++ b/Obsidian.Tests/Noise.cs
@@ -21,18 +21,11 @@ namespace Obsidian.Tests
 
                 var map = new NoiseMap();
 
-                PlaneNoiseMapBuilder builder = new PlaneNoiseMapBuilder()
-                {
-                    DestNoiseMap = map,
-                    SourceModule = noiseGen.Result
-                };
+                PlaneNoiseMapBuilder builder =
+                    new PlaneNoiseMapBuilder() {DestNoiseMap = map, SourceModule = noiseGen.Result};
 
                 var image = new SharpNoise.Utilities.Imaging.Image();
-                var renderer = new ImageRenderer()
-                {
-                    SourceNoiseMap = map,
-                    DestinationImage = image
-                };
+                var renderer = new ImageRenderer() {SourceNoiseMap = map, DestinationImage = image};
 
                 //renderer.BuildGrayscaleGradient();
                 renderer.BuildTerrainGradient();

--- a/Obsidian.Tests/Noise.cs
+++ b/Obsidian.Tests/Noise.cs
@@ -4,6 +4,7 @@ using Obsidian.WorldData.Generators.Overworld.Terrain;
 using SharpNoise;
 using SharpNoise.Builders;
 using SharpNoise.Utilities.Imaging;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Obsidian.Tests
@@ -13,37 +14,40 @@ namespace Obsidian.Tests
         [Fact(DisplayName = "WorldGen", Timeout = 100)]
         public async void SameAsync()
         {
-            OverworldGenerator og = new OverworldGenerator("1");
-            OverworldTerrain noiseGen = new OverworldTerrain(true);
-
-            var map = new NoiseMap();
-
-            PlaneNoiseMapBuilder builder = new PlaneNoiseMapBuilder()
+            await Task.Run(() =>
             {
-                DestNoiseMap = map,
-                SourceModule = noiseGen.Result
-            };
+                OverworldGenerator og = new OverworldGenerator("1");
+                OverworldTerrain noiseGen = new OverworldTerrain(true);
 
-            var image = new SharpNoise.Utilities.Imaging.Image();
-            var renderer = new ImageRenderer()
-            {
-                SourceNoiseMap = map,
-                DestinationImage = image
-            };
+                var map = new NoiseMap();
 
-            //renderer.BuildGrayscaleGradient();
-            renderer.BuildTerrainGradient();
+                PlaneNoiseMapBuilder builder = new PlaneNoiseMapBuilder()
+                {
+                    DestNoiseMap = map,
+                    SourceModule = noiseGen.Result
+                };
 
-            builder.SetBounds(-2000, 2000, -2000, 2000);
-            builder.SetDestSize(4000, 4000);
-            builder.Build();
+                var image = new SharpNoise.Utilities.Imaging.Image();
+                var renderer = new ImageRenderer()
+                {
+                    SourceNoiseMap = map,
+                    DestinationImage = image
+                };
 
-            renderer.Render();
+                //renderer.BuildGrayscaleGradient();
+                renderer.BuildTerrainGradient();
 
-            var bmp = renderer.DestinationImage.ToGdiBitmap();
-            bmp.Save("terrain.bmp");
+                builder.SetBounds(-2000, 2000, -2000, 2000);
+                builder.SetDestSize(4000, 4000);
+                builder.Build();
 
-            Assert.Equal(0, 0);
+                renderer.Render();
+
+                var bmp = renderer.DestinationImage.ToGdiBitmap();
+                bmp.Save("terrain.bmp");
+
+                Assert.Equal(0, 0);
+            });
         }
     }
 }

--- a/Obsidian/Commands/MainCommandModule.cs
+++ b/Obsidian/Commands/MainCommandModule.cs
@@ -370,7 +370,8 @@ namespace Obsidian.Commands
         [Command("time")]
         [CommandInfo("Sets declared time", "/time <timeOfDay>")]
         [IssuerScope(CommandIssuers.Client)]
-        public async Task TimeAsync(CommandContext Context) => TimeAsync(Context, 1337);
+        public async Task TimeAsync(CommandContext Context) => await TimeAsync(Context, 1337);
+
         [CommandOverload]
         public async Task TimeAsync(CommandContext Context,int time)
         {

--- a/Obsidian/Commands/MainCommandModule.cs
+++ b/Obsidian/Commands/MainCommandModule.cs
@@ -75,15 +75,15 @@ namespace Obsidian.Commands
                 {
                     Text = $"\n{ChatColor.Gold}{usage}",
                     ClickEvent = new ClickComponent
-                    {
-                        Action = EClickAction.SuggestCommand,
-                        Value = usage.Contains(' ') ? $"{usage.Substring(0, usage.IndexOf(' '))} " : usage
-                    },
+                    (
+                        EClickAction.SuggestCommand,
+                        usage.Contains(' ') ? $"{usage.Substring(0, usage.IndexOf(' '))} " : usage
+                    ),
                     HoverEvent = new HoverComponent
-                    {
-                        Action = EHoverAction.ShowText,
-                        Contents = $"Click to suggest the command"
-                    }
+                    (
+                        EHoverAction.ShowText,
+                        $"Click to suggest the command"
+                    )
                 };
                 commands.AddExtra(commandName);
 
@@ -142,9 +142,14 @@ namespace Obsidian.Commands
                 plugin.Text = pluginContainer.Info.Name;
                 plugin.Color = colorByState;
 
-                plugin.HoverEvent = new HoverComponent { Action = EHoverAction.ShowText, Contents = $"{colorByState}{info.Name}{ChatColor.Reset}\nVersion: {colorByState}{info.Version}{ChatColor.Reset}\nAuthor(s): {colorByState}{info.Authors}{ChatColor.Reset}" };
+                plugin.HoverEvent = new HoverComponent 
+                ( 
+                    EHoverAction.ShowText, 
+                    $"{colorByState}{info.Name}{ChatColor.Reset}\nVersion: {colorByState}{info.Version}{ChatColor.Reset}\nAuthor(s): {colorByState}{info.Authors}{ChatColor.Reset}" 
+                );
+
                 if (pluginContainer.Info.ProjectUrl != null)
-                    plugin.ClickEvent = new ClickComponent { Action = EClickAction.OpenUrl, Value = pluginContainer.Info.ProjectUrl.AbsoluteUri };
+                    plugin.ClickEvent = new ClickComponent (EClickAction.OpenUrl, pluginContainer.Info.ProjectUrl.AbsoluteUri);
 
                 messages.Add(plugin);
 
@@ -462,15 +467,15 @@ namespace Obsidian.Commands
             {
                 Text = $"{ChatColor.Red}{commandUsage}",
                 ClickEvent = new ClickComponent
-                {
-                    Action = EClickAction.SuggestCommand,
-                    Value = $"{commandSuggest}"
-                },
+                (
+                    EClickAction.SuggestCommand,
+                    $"{commandSuggest}"
+                ),
                 HoverEvent = new HoverComponent
-                {
-                    Action = EHoverAction.ShowText,
-                    Contents = $"Click to suggest the command"
-                }
+                (
+                    EHoverAction.ShowText,
+                    $"Click to suggest the command"
+                )
             };
 
             var prefix = new ChatMessage

--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -35,7 +35,7 @@ namespace Obsidian.Entities
         public string Username { get; }
 
         /// <summary>
-        /// The players inventory
+        /// The players inventory.
         /// </summary>
         public Inventory Inventory { get; }
         public Inventory OpenedInventory { get; set; }

--- a/Obsidian/Events/EventArgs/BasePacketEventArgs.cs
+++ b/Obsidian/Events/EventArgs/BasePacketEventArgs.cs
@@ -6,12 +6,12 @@ namespace Obsidian.Events.EventArgs
     public class BasePacketEventArgs : AsyncEventArgs
     {
         /// <summary>
-        /// The client that invoked the event
+        /// The client that invoked the event.
         /// </summary>
         public Client Client { get; set; }
 
         /// <summary>
-        /// The packet being used to invoke this event
+        /// The packet being used to invoke this event.
         /// </summary>
         public IPacket Packet { get; private set; }
 

--- a/Obsidian/NativeMethods.cs
+++ b/Obsidian/NativeMethods.cs
@@ -3,7 +3,7 @@
 namespace Obsidian
 {
     /// <summary>
-    /// Native methods for Windows
+    /// Native methods for Windows.
     /// </summary>
     internal static class NativeMethods
     {

--- a/Obsidian/Net/Packets/Play/Clientbound/BlockBreakAnimation.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/BlockBreakAnimation.cs
@@ -12,7 +12,7 @@ namespace Obsidian.Net.Packets.Play.Clientbound
         public VectorF Position { get; init; }
 
         /// <summary>
-        /// 0-9 to set it, any other value to remove it
+        /// 0-9 to set it, any other value to remove it.
         /// </summary>
         [Field(2)]
         public sbyte DestroyStage { get; init; }

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Obsidian/Plugins/PluginContainer.cs
+++ b/Obsidian/Plugins/PluginContainer.cs
@@ -157,7 +157,7 @@ namespace Obsidian.Plugins
                     return null;
                 }
 
-                wrapper.Plugin = plugin;
+                wrapper.plugin = plugin;
 
                 Type pluginType = plugin.GetType();
                 var methods = pluginType.GetMethods();

--- a/Obsidian/Plugins/PluginContainer.cs
+++ b/Obsidian/Plugins/PluginContainer.cs
@@ -157,7 +157,7 @@ namespace Obsidian.Plugins
                     return null;
                 }
 
-                wrapper.plugin = plugin;
+                wrapper.Plugin = plugin;
 
                 Type pluginType = plugin.GetType();
                 var methods = pluginType.GetMethods();

--- a/Obsidian/Plugins/Services/DiagnoserService.cs
+++ b/Obsidian/Plugins/Services/DiagnoserService.cs
@@ -32,7 +32,7 @@ namespace Obsidian.Plugins.Services
             return Process.GetProcesses().Select(process => new ProcessService(process, this)).ToArray();
         }
 
-        public IProcess StartProcess(string fileName, string arguments = null, bool createWindow = true, bool useShell = false)
+        public IProcess StartProcess(string fileName, string? arguments = null, bool createWindow = true, bool useShell = false)
         {
             if (!IsUsable)
                 throw new SecurityException(IDiagnoser.SecurityExceptionMessage);
@@ -40,7 +40,7 @@ namespace Obsidian.Plugins.Services
             var processInfo = new ProcessStartInfo
             {
                 FileName = fileName,
-                Arguments = arguments,
+                Arguments = arguments ?? string.Empty,
                 CreateNoWindow = !createWindow,
                 UseShellExecute = useShell
             };

--- a/Obsidian/Scoreboard.cs
+++ b/Obsidian/Scoreboard.cs
@@ -41,11 +41,11 @@ namespace Obsidian
             else
             {
                 this.Objective = new ScoreboardObjective
-                {
-                    ObjectiveName = this.name,
-                    Value = title,
-                    DisplayType = displayType
-                };
+                (
+                    this.name,
+                    title,
+                    displayType
+                );
 
                 foreach (var (_, player) in this.server.OnlinePlayers)
                 {
@@ -70,11 +70,7 @@ namespace Obsidian
 
         public async Task CreateOrUpdateScoreAsync(string scoreName, string displayText, int? value = null)
         {
-            var score = new Score
-            {
-                DisplayText = displayText,
-                Value = value ?? 0
-            };
+            var score = new Score(displayText, value ?? 0);
 
             if (this.scores.TryGetValue(scoreName, out var cachedScore))
             {

--- a/Obsidian/Utilities/RentedArray.cs
+++ b/Obsidian/Utilities/RentedArray.cs
@@ -27,13 +27,19 @@ namespace Obsidian.Utilities
         /// </summary>
         public Memory<T> Memory => array.AsMemory(0, Length);
 
+#nullable enable
+        /// <summary>
+        /// #nullable
+        /// </summary>
+        /// <param name="length"></param>
+        /// <param name="pool"></param>
         public RentedArray(int length, ArrayPool<T>? pool = null)
         {
             this.pool = pool ?? ArrayPool<T>.Shared;
             array = this.pool.Rent(length);
             Length = length;
         }
-        
+#nullable disable
 
         /// <summary>
         /// Returns the rented array to the pool

--- a/Obsidian/Utilities/RentedArray.cs
+++ b/Obsidian/Utilities/RentedArray.cs
@@ -27,14 +27,12 @@ namespace Obsidian.Utilities
         /// </summary>
         public Memory<T> Memory => array.AsMemory(0, Length);
 
-#nullable enable
         public RentedArray(int length, ArrayPool<T>? pool = null)
         {
             this.pool = pool ?? ArrayPool<T>.Shared;
             array = this.pool.Rent(length);
             Length = length;
         }
-#nullable disable
 
         /// <summary>
         /// Returns the rented array to the pool

--- a/Obsidian/Utilities/RentedArray.cs
+++ b/Obsidian/Utilities/RentedArray.cs
@@ -28,11 +28,6 @@ namespace Obsidian.Utilities
         public Memory<T> Memory => array.AsMemory(0, Length);
 
 #nullable enable
-        /// <summary>
-        /// #nullable
-        /// </summary>
-        /// <param name="length"></param>
-        /// <param name="pool"></param>
         public RentedArray(int length, ArrayPool<T>? pool = null)
         {
             this.pool = pool ?? ArrayPool<T>.Shared;

--- a/Obsidian/WorldData/BlockUpdates.cs
+++ b/Obsidian/WorldData/BlockUpdates.cs
@@ -27,166 +27,163 @@ namespace Obsidian.WorldData
 
         internal static async Task<bool> HandleLiquidPhysics(BlockUpdate blockUpdate)
         {
-            return await Task.Run(() =>
+            if (blockUpdate.block is null) { return false; }
+
+            var block = blockUpdate.block.Value;
+            var world = blockUpdate.world;
+            var location = blockUpdate.position;
+            int state = block.State;
+            Vector belowPos = location + Vector.Down;
+
+            // Handle the initial search for closet path downwards.
+            // Just going to do a crappy pathfind for now. We can do
+            // proper pathfinding some other time.
+            if (state == 0)
             {
-                if (blockUpdate.block is null) { return false; }
+                var validPaths = new List<Vector>();
+                var paths = new List<Vector>() {
+                    {location + Vector.Forwards},
+                    {location + Vector.Backwards},
+                    {location + Vector.Left},
+                    {location + Vector.Right}
+                };
 
-                var block = blockUpdate.block.Value;
-                var world = blockUpdate.world;
-                var location = blockUpdate.position;
-                int state = block.State;
-                Vector belowPos = location + Vector.Down;
-
-                // Handle the initial search for closet path downwards.
-                // Just going to do a crappy pathfind for now. We can do
-                // proper pathfinding some other time.
-                if (state == 0)
+                foreach (var pathLoc in paths)
                 {
-                    var validPaths = new List<Vector>();
-                    var paths = new List<Vector>() {
-                        {location + Vector.Forwards},
-                        {location + Vector.Backwards},
-                        {location + Vector.Left},
-                        {location + Vector.Right}
-                    };
-
-                    foreach (var pathLoc in paths)
+                    if (world.GetBlock(pathLoc) is Block pathSide &&
+                        (Block.Replaceable.Contains(pathSide.Material) || pathSide.IsFluid))
                     {
-                        if (world.GetBlock(pathLoc) is Block pathSide &&
-                            (Block.Replaceable.Contains(pathSide.Material) || pathSide.IsFluid))
+                        var pathBelow = world.GetBlock(pathLoc + Vector.Down);
+                        if (pathBelow is Block pBelow &&
+                            (Block.Replaceable.Contains(pBelow.Material) || pBelow.IsFluid))
                         {
-                            var pathBelow = world.GetBlock(pathLoc + Vector.Down);
-                            if (pathBelow is Block pBelow &&
-                                (Block.Replaceable.Contains(pBelow.Material) || pBelow.IsFluid))
-                            {
-                                validPaths.Add(pathLoc);
-                            }
+                            validPaths.Add(pathLoc);
+                        }
+                    }
+                }
+
+                // if all directions are valid, or none are, use normal liquid spread physics instead
+                if (validPaths.Count != 4 && validPaths.Count != 0)
+                {
+                    var path = validPaths[0];
+                    var newBlock = new Block(block.BaseId, state + 1);
+                    world.SetBlock(path, newBlock);
+                    var neighborUpdate = new BlockUpdate(world, path, newBlock);
+                    world.ScheduleBlockUpdate(neighborUpdate);
+                    return false;
+                }
+            }
+
+            if (state >= 8) // Falling water
+            {
+                // If above me is no longer water, than I should disappear too
+                if (world.GetBlock(location + Vector.Up) is Block up && !up.IsFluid)
+                {
+                    world.SetBlock(location, Block.Air);
+                    world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos));
+                    return false;
+                }
+
+                // Keep falling
+                if (world.GetBlock(belowPos) is Block below && Block.Replaceable.Contains(below.Material))
+                {
+                    var newBlock = new Block(block.BaseId, state);
+                    world.SetBlock(belowPos, newBlock);
+                    world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos, newBlock));
+                    return false;
+                }
+                else
+                {
+                    // Falling water has hit something solid. Change state to spread.
+                    state = 1;
+                    world.SetBlockUntracked(location, new Block(block.BaseId, state));
+                }
+            }
+
+            if (state < 8)
+            {
+                var horizontalNeighbors = new Dictionary<Vector, Block?>() {
+                    {location + Vector.Forwards, world.GetBlock(location + Vector.Forwards)},
+                    {location + Vector.Backwards, world.GetBlock(location + Vector.Backwards)},
+                    {location + Vector.Left, world.GetBlock(location + Vector.Left)},
+                    {location + Vector.Right, world.GetBlock(location + Vector.Right)}
+                };
+
+                // Check infinite source blocks
+                if (state == 1 && block.Material == Material.Water)
+                {
+                    // if 2 neighbors are source blocks (state = 0), then become source block
+                    int sourceNeighborCount = 0;
+                    foreach (var (loc, neighborBlock) in horizontalNeighbors)
+                    {
+                        if (neighborBlock is Block neighbor && neighbor.Material == block.Material &&
+                            neighbor.State == 0)
+                        {
+                            sourceNeighborCount++;
                         }
                     }
 
-                    // if all directions are valid, or none are, use normal liquid spread physics instead
-                    if (validPaths.Count != 4 && validPaths.Count != 0)
+                    if (sourceNeighborCount > 1)
                     {
-                        var path = validPaths[0];
-                        var newBlock = new Block(block.BaseId, state + 1);
-                        world.SetBlock(path, newBlock);
-                        var neighborUpdate = new BlockUpdate(world, path, newBlock);
+                        var newBlock = new Block(Material.Water);
+                        world.SetBlock(location, newBlock);
+                        return true;
+                    }
+                }
+
+                if (state > 0)
+                {
+                    // On some side of the block, there should be another water block with a lower state.
+                    int lowestState = state;
+                    foreach (var (loc, neighborBlock) in horizontalNeighbors)
+                    {
+                        if (neighborBlock.Value.Material == block.Material)
+                            lowestState = Math.Min(lowestState, neighborBlock.Value.State);
+                    }
+
+                    // If not, turn to air and update neighbors.
+                    if (lowestState >= state &&
+                        world.GetBlock(location + Vector.Up).Value.Material != block.Material)
+                    {
+                        world.SetBlock(location, Block.Air);
+                        return true;
+                    }
+                }
+
+                if (world.GetBlock(belowPos) is Block below)
+                {
+                    if (below.Material == block.Material) { return false; }
+
+                    if (Block.Replaceable.Contains(below.Material))
+                    {
+                        var newBlock = new Block(block.BaseId, state + 8);
+                        world.SetBlock(belowPos, newBlock);
+                        var neighborUpdate = new BlockUpdate(world, belowPos, newBlock);
                         world.ScheduleBlockUpdate(neighborUpdate);
                         return false;
                     }
                 }
 
-                if (state >= 8) // Falling water
-                {
-                    // If above me is no longer water, than I should disappear too
-                    if (world.GetBlock(location + Vector.Up) is Block up && !up.IsFluid)
-                    {
-                        world.SetBlock(location, Block.Air);
-                        world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos));
-                        return false;
-                    }
+                // the lowest level of water can only go down, so bail now.
+                if (state == 7) { return false; }
 
-                    // Keep falling
-                    if (world.GetBlock(belowPos) is Block below && Block.Replaceable.Contains(below.Material))
+                foreach (var (loc, neighborBlock) in horizontalNeighbors)
+                {
+                    if (neighborBlock is null) { continue; }
+
+                    var neighbor = neighborBlock.Value;
+                    if (Block.Replaceable.Contains(neighbor.Material) ||
+                        (neighbor.Material == block.Material && neighbor.State > state + 1))
                     {
-                        var newBlock = new Block(block.BaseId, state);
-                        world.SetBlock(belowPos, newBlock);
-                        world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos, newBlock));
-                        return false;
-                    }
-                    else
-                    {
-                        // Falling water has hit something solid. Change state to spread.
-                        state = 1;
-                        world.SetBlockUntracked(location, new Block(block.BaseId, state));
+                        var newBlock = new Block(block.BaseId, state + 1);
+                        world.SetBlock(loc, newBlock);
+                        var neighborUpdate = new BlockUpdate(world, loc, newBlock);
+                        world.ScheduleBlockUpdate(neighborUpdate);
                     }
                 }
+            }
 
-                if (state < 8)
-                {
-                    var horizontalNeighbors = new Dictionary<Vector, Block?>() {
-                        {location + Vector.Forwards, world.GetBlock(location + Vector.Forwards)},
-                        {location + Vector.Backwards, world.GetBlock(location + Vector.Backwards)},
-                        {location + Vector.Left, world.GetBlock(location + Vector.Left)},
-                        {location + Vector.Right, world.GetBlock(location + Vector.Right)}
-                    };
-
-                    // Check infinite source blocks
-                    if (state == 1 && block.Material == Material.Water)
-                    {
-                        // if 2 neighbors are source blocks (state = 0), then become source block
-                        int sourceNeighborCount = 0;
-                        foreach (var (loc, neighborBlock) in horizontalNeighbors)
-                        {
-                            if (neighborBlock is Block neighbor && neighbor.Material == block.Material &&
-                                neighbor.State == 0)
-                            {
-                                sourceNeighborCount++;
-                            }
-                        }
-
-                        if (sourceNeighborCount > 1)
-                        {
-                            var newBlock = new Block(Material.Water);
-                            world.SetBlock(location, newBlock);
-                            return true;
-                        }
-                    }
-
-                    if (state > 0)
-                    {
-                        // On some side of the block, there should be another water block with a lower state.
-                        int lowestState = state;
-                        foreach (var (loc, neighborBlock) in horizontalNeighbors)
-                        {
-                            if (neighborBlock.Value.Material == block.Material)
-                                lowestState = Math.Min(lowestState, neighborBlock.Value.State);
-                        }
-
-                        // If not, turn to air and update neighbors.
-                        if (lowestState >= state &&
-                            world.GetBlock(location + Vector.Up).Value.Material != block.Material)
-                        {
-                            world.SetBlock(location, Block.Air);
-                            return true;
-                        }
-                    }
-
-                    if (world.GetBlock(belowPos) is Block below)
-                    {
-                        if (below.Material == block.Material) { return false; }
-
-                        if (Block.Replaceable.Contains(below.Material))
-                        {
-                            var newBlock = new Block(block.BaseId, state + 8);
-                            world.SetBlock(belowPos, newBlock);
-                            var neighborUpdate = new BlockUpdate(world, belowPos, newBlock);
-                            world.ScheduleBlockUpdate(neighborUpdate);
-                            return false;
-                        }
-                    }
-
-                    // the lowest level of water can only go down, so bail now.
-                    if (state == 7) { return false; }
-
-                    foreach (var (loc, neighborBlock) in horizontalNeighbors)
-                    {
-                        if (neighborBlock is null) { continue; }
-
-                        var neighbor = neighborBlock.Value;
-                        if (Block.Replaceable.Contains(neighbor.Material) ||
-                            (neighbor.Material == block.Material && neighbor.State > state + 1))
-                        {
-                            var newBlock = new Block(block.BaseId, state + 1);
-                            world.SetBlock(loc, newBlock);
-                            var neighborUpdate = new BlockUpdate(world, loc, newBlock);
-                            world.ScheduleBlockUpdate(neighborUpdate);
-                        }
-                    }
-                }
-
-                return false;
-            });
+            return false;
         }
     }
 }

--- a/Obsidian/WorldData/BlockUpdates.cs
+++ b/Obsidian/WorldData/BlockUpdates.cs
@@ -25,24 +25,24 @@ namespace Obsidian.WorldData
             });
         }
 
-        // TODO: This method will need to be implemented as above if it is going to be declared async
-        // HenryMigo 30/10/2021
         internal static async Task<bool> HandleLiquidPhysics(BlockUpdate blockUpdate)
         {
-            if (blockUpdate.block is null) { return false; }
-            var block = blockUpdate.block.Value;
-            var world = blockUpdate.world;
-            var location = blockUpdate.position;
-            int state = block.State;
-            Vector belowPos = location + Vector.Down;
-
-            // Handle the initial search for closet path downwards.
-            // Just going to do a crappy pathfind for now. We can do
-            // proper pathfinding some other time.
-            if (state == 0)
+            return await Task.Run(() =>
             {
-                var validPaths = new List<Vector>();
-                var paths = new List<Vector>()
+                if (blockUpdate.block is null) { return false; }
+                var block = blockUpdate.block.Value;
+                var world = blockUpdate.world;
+                var location = blockUpdate.position;
+                int state = block.State;
+                Vector belowPos = location + Vector.Down;
+
+                // Handle the initial search for closet path downwards.
+                // Just going to do a crappy pathfind for now. We can do
+                // proper pathfinding some other time.
+                if (state == 0)
+                {
+                    var validPaths = new List<Vector>();
+                    var paths = new List<Vector>()
                 {
                     { location + Vector.Forwards },
                     { location + Vector.Backwards },
@@ -50,59 +50,59 @@ namespace Obsidian.WorldData
                     { location + Vector.Right }
                 };
 
-                foreach (var pathLoc in paths)
-                {
-                    if (world.GetBlock(pathLoc) is Block pathSide && (Block.Replaceable.Contains(pathSide.Material) || pathSide.IsFluid))
+                    foreach (var pathLoc in paths)
                     {
-                        var pathBelow = world.GetBlock(pathLoc + Vector.Down);
-                        if (pathBelow is Block pBelow && (Block.Replaceable.Contains(pBelow.Material) || pBelow.IsFluid))
+                        if (world.GetBlock(pathLoc) is Block pathSide && (Block.Replaceable.Contains(pathSide.Material) || pathSide.IsFluid))
                         {
-                            validPaths.Add(pathLoc);
+                            var pathBelow = world.GetBlock(pathLoc + Vector.Down);
+                            if (pathBelow is Block pBelow && (Block.Replaceable.Contains(pBelow.Material) || pBelow.IsFluid))
+                            {
+                                validPaths.Add(pathLoc);
+                            }
                         }
+                    }
+
+                    // if all directions are valid, or none are, use normal liquid spread physics instead
+                    if (validPaths.Count != 4 && validPaths.Count != 0)
+                    {
+                        var path = validPaths[0];
+                        var newBlock = new Block(block.BaseId, state + 1);
+                        world.SetBlock(path, newBlock);
+                        var neighborUpdate = new BlockUpdate(world, path, newBlock);
+                        world.ScheduleBlockUpdate(neighborUpdate);
+                        return false;
                     }
                 }
 
-                // if all directions are valid, or none are, use normal liquid spread physics instead
-                if (validPaths.Count != 4 && validPaths.Count != 0)
+                if (state >= 8) // Falling water
                 {
-                    var path = validPaths[0];
-                    var newBlock = new Block(block.BaseId, state + 1);
-                    world.SetBlock(path, newBlock);
-                    var neighborUpdate = new BlockUpdate(world, path, newBlock);
-                    world.ScheduleBlockUpdate(neighborUpdate);
-                    return false;
-                }
-            }
+                    // If above me is no longer water, than I should disappear too
+                    if (world.GetBlock(location + Vector.Up) is Block up && !up.IsFluid)
+                    {
+                        world.SetBlock(location, Block.Air);
+                        world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos));
+                        return false;
+                    }
 
-            if (state >= 8) // Falling water
-            {
-                // If above me is no longer water, than I should disappear too
-                if (world.GetBlock(location + Vector.Up) is Block up && !up.IsFluid)
-                {
-                    world.SetBlock(location, Block.Air);
-                    world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos));
-                    return false;
+                    // Keep falling
+                    if (world.GetBlock(belowPos) is Block below && Block.Replaceable.Contains(below.Material))
+                    {
+                        var newBlock = new Block(block.BaseId, state);
+                        world.SetBlock(belowPos, newBlock);
+                        world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos, newBlock));
+                        return false;
+                    }
+                    else
+                    {
+                        // Falling water has hit something solid. Change state to spread.
+                        state = 1;
+                        world.SetBlockUntracked(location, new Block(block.BaseId, state));
+                    }
                 }
 
-                // Keep falling
-                if (world.GetBlock(belowPos) is Block below && Block.Replaceable.Contains(below.Material))
+                if (state < 8)
                 {
-                    var newBlock = new Block(block.BaseId, state);
-                    world.SetBlock(belowPos, newBlock);
-                    world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos, newBlock));
-                    return false;
-                }
-                else
-                {
-                    // Falling water has hit something solid. Change state to spread.
-                    state = 1;
-                    world.SetBlockUntracked(location, new Block(block.BaseId, state));
-                }
-            }
-
-            if (state < 8)
-            {
-                var horizontalNeighbors = new Dictionary<Vector, Block?>()
+                    var horizontalNeighbors = new Dictionary<Vector, Block?>()
                 {
                     { location + Vector.Forwards, world.GetBlock(location + Vector.Forwards) },
                     { location + Vector.Backwards, world.GetBlock(location + Vector.Backwards) },
@@ -110,75 +110,76 @@ namespace Obsidian.WorldData
                     { location + Vector.Right, world.GetBlock(location + Vector.Right) }
                 };
 
-                // Check infinite source blocks
-                if (state == 1 && block.Material == Material.Water)
-                {
-                    // if 2 neighbors are source blocks (state = 0), then become source block
-                    int sourceNeighborCount = 0;
-                    foreach (var (loc, neighborBlock) in horizontalNeighbors)
+                    // Check infinite source blocks
+                    if (state == 1 && block.Material == Material.Water)
                     {
-                        if (neighborBlock is Block neighbor && neighbor.Material == block.Material && neighbor.State == 0)
+                        // if 2 neighbors are source blocks (state = 0), then become source block
+                        int sourceNeighborCount = 0;
+                        foreach (var (loc, neighborBlock) in horizontalNeighbors)
                         {
-                            sourceNeighborCount++;
+                            if (neighborBlock is Block neighbor && neighbor.Material == block.Material && neighbor.State == 0)
+                            {
+                                sourceNeighborCount++;
+                            }
+                        }
+                        if (sourceNeighborCount > 1)
+                        {
+                            var newBlock = new Block(Material.Water);
+                            world.SetBlock(location, newBlock);
+                            return true;
                         }
                     }
-                    if (sourceNeighborCount > 1)
-                    {
-                        var newBlock = new Block(Material.Water);
-                        world.SetBlock(location, newBlock);
-                        return true;
-                    }
-                }
 
-                if (state > 0)
-                {
-                    // On some side of the block, there should be another water block with a lower state.
-                    int lowestState = state;
+                    if (state > 0)
+                    {
+                        // On some side of the block, there should be another water block with a lower state.
+                        int lowestState = state;
+                        foreach (var (loc, neighborBlock) in horizontalNeighbors)
+                        {
+                            if (neighborBlock.Value.Material == block.Material)
+                                lowestState = Math.Min(lowestState, neighborBlock.Value.State);
+                        }
+
+                        // If not, turn to air and update neighbors.
+                        if (lowestState >= state && world.GetBlock(location + Vector.Up).Value.Material != block.Material)
+                        {
+                            world.SetBlock(location, Block.Air);
+                            return true;
+                        }
+                    }
+
+                    if (world.GetBlock(belowPos) is Block below)
+                    {
+                        if (below.Material == block.Material) { return false; }
+                        if (Block.Replaceable.Contains(below.Material))
+                        {
+                            var newBlock = new Block(block.BaseId, state + 8);
+                            world.SetBlock(belowPos, newBlock);
+                            var neighborUpdate = new BlockUpdate(world, belowPos, newBlock);
+                            world.ScheduleBlockUpdate(neighborUpdate);
+                            return false;
+                        }
+                    }
+
+                    // the lowest level of water can only go down, so bail now.
+                    if (state == 7) { return false; }
+
                     foreach (var (loc, neighborBlock) in horizontalNeighbors)
                     {
-                        if (neighborBlock.Value.Material == block.Material)
-                            lowestState = Math.Min(lowestState, neighborBlock.Value.State);
-                    }
-
-                    // If not, turn to air and update neighbors.
-                    if (lowestState >= state && world.GetBlock(location + Vector.Up).Value.Material != block.Material)
-                    {
-                        world.SetBlock(location, Block.Air);
-                        return true;
-                    }
-                }
-
-                if (world.GetBlock(belowPos) is Block below)
-                {
-                    if (below.Material == block.Material) { return false; }
-                    if (Block.Replaceable.Contains(below.Material))
-                    {
-                        var newBlock = new Block(block.BaseId, state + 8);
-                        world.SetBlock(belowPos, newBlock);
-                        var neighborUpdate = new BlockUpdate(world, belowPos, newBlock);
-                        world.ScheduleBlockUpdate(neighborUpdate);
-                        return false;
+                        if (neighborBlock is null) { continue; }
+                        var neighbor = neighborBlock.Value;
+                        if (Block.Replaceable.Contains(neighbor.Material) || (neighbor.Material == block.Material && neighbor.State > state + 1))
+                        {
+                            var newBlock = new Block(block.BaseId, state + 1);
+                            world.SetBlock(loc, newBlock);
+                            var neighborUpdate = new BlockUpdate(world, loc, newBlock);
+                            world.ScheduleBlockUpdate(neighborUpdate);
+                        }
                     }
                 }
 
-                // the lowest level of water can only go down, so bail now.
-                if (state == 7) { return false; }
-
-                foreach (var (loc, neighborBlock) in horizontalNeighbors)
-                {
-                    if (neighborBlock is null) { continue; }
-                    var neighbor = neighborBlock.Value;
-                    if (Block.Replaceable.Contains(neighbor.Material) || (neighbor.Material == block.Material && neighbor.State > state + 1))
-                    {
-                        var newBlock = new Block(block.BaseId, state + 1);
-                        world.SetBlock(loc, newBlock);
-                        var neighborUpdate = new BlockUpdate(world, loc, newBlock);
-                        world.ScheduleBlockUpdate(neighborUpdate);
-                    }
-                }
-            }
-
-            return false;
+                return false;
+            });
         }
     }
 }

--- a/Obsidian/WorldData/BlockUpdates.cs
+++ b/Obsidian/WorldData/BlockUpdates.cs
@@ -25,9 +25,9 @@ namespace Obsidian.WorldData
             return false;
         }
 
-        internal static async Task<bool> HandleLiquidPhysics(BlockUpdate blockUpdate)
+        internal static Task<bool> HandleLiquidPhysics(BlockUpdate blockUpdate)
         {
-            if (blockUpdate.block is null) { return false; }
+            if (blockUpdate.block is null) { return Task.FromResult(false); }
 
             var block = blockUpdate.block.Value;
             var world = blockUpdate.world;
@@ -70,7 +70,7 @@ namespace Obsidian.WorldData
                     world.SetBlock(path, newBlock);
                     var neighborUpdate = new BlockUpdate(world, path, newBlock);
                     world.ScheduleBlockUpdate(neighborUpdate);
-                    return false;
+                    return Task.FromResult(false);
                 }
             }
 
@@ -81,7 +81,7 @@ namespace Obsidian.WorldData
                 {
                     world.SetBlock(location, Block.Air);
                     world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos));
-                    return false;
+                    return Task.FromResult(false);
                 }
 
                 // Keep falling
@@ -90,7 +90,7 @@ namespace Obsidian.WorldData
                     var newBlock = new Block(block.BaseId, state);
                     world.SetBlock(belowPos, newBlock);
                     world.ScheduleBlockUpdate(new BlockUpdate(world, belowPos, newBlock));
-                    return false;
+                    return Task.FromResult(false);
                 }
                 else
                 {
@@ -127,7 +127,7 @@ namespace Obsidian.WorldData
                     {
                         var newBlock = new Block(Material.Water);
                         world.SetBlock(location, newBlock);
-                        return true;
+                        return Task.FromResult(true);
                     }
                 }
 
@@ -146,13 +146,13 @@ namespace Obsidian.WorldData
                         world.GetBlock(location + Vector.Up).Value.Material != block.Material)
                     {
                         world.SetBlock(location, Block.Air);
-                        return true;
+                        return Task.FromResult(true);
                     }
                 }
 
                 if (world.GetBlock(belowPos) is Block below)
                 {
-                    if (below.Material == block.Material) { return false; }
+                    if (below.Material == block.Material) { return Task.FromResult(false); }
 
                     if (Block.Replaceable.Contains(below.Material))
                     {
@@ -160,12 +160,12 @@ namespace Obsidian.WorldData
                         world.SetBlock(belowPos, newBlock);
                         var neighborUpdate = new BlockUpdate(world, belowPos, newBlock);
                         world.ScheduleBlockUpdate(neighborUpdate);
-                        return false;
+                        return Task.FromResult(false);
                     }
                 }
 
                 // the lowest level of water can only go down, so bail now.
-                if (state == 7) { return false; }
+                if (state == 7) { return Task.FromResult(false); }
 
                 foreach (var (loc, neighborBlock) in horizontalNeighbors)
                 {
@@ -183,7 +183,7 @@ namespace Obsidian.WorldData
                 }
             }
 
-            return false;
+            return Task.FromResult(false);
         }
     }
 }

--- a/Obsidian/WorldData/BlockUpdates.cs
+++ b/Obsidian/WorldData/BlockUpdates.cs
@@ -9,19 +9,24 @@ namespace Obsidian.WorldData
     {
         internal static async Task<bool> HandleFallingBlock(BlockUpdate blockUpdate)
         {
-            if (blockUpdate.block is null) { return false; }
-            var world = blockUpdate.world;
-            var location = blockUpdate.position;
-            var material = blockUpdate.block.Value.Material;
-            if (world.GetBlock(location + Vector.Down) is Block below && (Block.Replaceable.Contains(below.Material) || below.IsFluid))
+            return await Task.Run(() =>
             {
-                world.SetBlock(location, Block.Air);
-                world.SpawnFallingBlock(location, material);
-                return true;
-            }
-            return false;
+                if (blockUpdate.block is null) { return false; }
+                var world = blockUpdate.world;
+                var location = blockUpdate.position;
+                var material = blockUpdate.block.Value.Material;
+                if (world.GetBlock(location + Vector.Down) is Block below && (Block.Replaceable.Contains(below.Material) || below.IsFluid))
+                {
+                    world.SetBlock(location, Block.Air);
+                    world.SpawnFallingBlock(location, material);
+                    return true;
+                }
+                return false;
+            });
         }
 
+        // TODO: This method will need to be implemented as above if it is going to be declared async
+        // HenryMigo 30/10/2021
         internal static async Task<bool> HandleLiquidPhysics(BlockUpdate blockUpdate)
         {
             if (blockUpdate.block is null) { return false; }
@@ -30,7 +35,7 @@ namespace Obsidian.WorldData
             var location = blockUpdate.position;
             int state = block.State;
             Vector belowPos = location + Vector.Down;
-            
+
             // Handle the initial search for closet path downwards.
             // Just going to do a crappy pathfind for now. We can do
             // proper pathfinding some other time.

--- a/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
+++ b/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
@@ -110,19 +110,14 @@ namespace Obsidian.WorldData.Generators.Overworld.Terrain
 
             var biomeTransitionSel2 = new Cache
             {
-                Source0 = new TransitionMap
-                {
-                    Distance = 5,
-                    Source0 = FinalBiomes
-                }
+                Source0 = new TransitionMap(FinalBiomes, 5)
             };
 
             Module scaled = new Blend(
-                new TerrainSelect
+                new TerrainSelect(FinalBiomes)
                 {
-                    BiomeSelector = FinalBiomes,
                     Control = biomeTransitionSel2,
-                    TerrainModules = biomesMap,
+                    TerrainModules = biomesMap
                 })
             {
                 Distance = 2

--- a/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
+++ b/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
@@ -117,15 +117,15 @@ namespace Obsidian.WorldData.Generators.Overworld.Terrain
                 }
             };
 
-            Module scaled = new Blend
-            {
-                Distance = 2,
-                Source0 = new TerrainSelect
+            Module scaled = new Blend(
+                new TerrainSelect
                 {
                     BiomeSelector = FinalBiomes,
                     Control = biomeTransitionSel2,
                     TerrainModules = biomesMap,
-                }
+                })
+            {
+                Distance = 2
             };
 
             if (isUnitTest)

--- a/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
+++ b/Obsidian/WorldData/Generators/Overworld/Terrain/OverworldTerrain.cs
@@ -20,8 +20,6 @@ namespace Obsidian.WorldData.Generators.Overworld.Terrain
 
         private Module FinalBiomes;
 
-        
-
         public OverworldTerrain(bool isUnitTest = false)
         {
             settings = OverworldGenerator.GeneratorSettings;

--- a/Obsidian/WorldData/RegionFile.cs
+++ b/Obsidian/WorldData/RegionFile.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Obsidian.WorldData
 {
-    public class RegionFile : IDisposable
+    public class RegionFile : IAsyncDisposable
     {
         private readonly string filePath;
         private readonly int cubicRegionSize;
@@ -227,13 +227,13 @@ namespace Obsidian.WorldData
         }
 
         #region IDisposable
-        protected virtual void Dispose(bool disposing)
+        protected async virtual Task DisposeAsync(bool disposing)
         {
             if (!disposedValue)
             {
                 if (disposing)
                 {
-                    Task.Run(async () => await FlushToDiskAsync());
+                    await FlushToDiskAsync();
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
@@ -249,10 +249,10 @@ namespace Obsidian.WorldData
         //     Dispose(disposing: false);
         // }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
+            // Do not change this code. Put cleanup code in 'DisposeAsync(bool disposing)' method
+            await DisposeAsync(true);
             GC.SuppressFinalize(this);
         }
         #endregion IDisposable

--- a/Obsidian/WorldData/RegionFile.cs
+++ b/Obsidian/WorldData/RegionFile.cs
@@ -233,7 +233,7 @@ namespace Obsidian.WorldData
             {
                 if (disposing)
                 {
-                    FlushToDiskAsync();
+                    Task.Run(async () => await FlushToDiskAsync());
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -529,9 +529,12 @@ namespace Obsidian.WorldData
 
         public async Task FlushRegionsAsync()
         {
-            Server.BroadcastMessage("Saving to disk...");
-            Parallel.ForEach(Regions.Values, async r => await r.FlushAsync());
-            Server.BroadcastMessage("Save complete.");
+            await Task.Run(() =>
+            {
+                Server.BroadcastMessage("Saving to disk...");
+                Parallel.ForEach(Regions.Values, async r => await r.FlushAsync());
+                Server.BroadcastMessage("Save complete.");
+            });
         }
 
         public IEntity SpawnFallingBlock(VectorF position, Material mat)

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -529,7 +529,7 @@ namespace Obsidian.WorldData
 
         public async Task FlushRegionsAsync()
         {
-            await Task.WhenAll(Regions.Values.Select(r => r.FlushAsync()));
+            await Task.WhenAll(Regions.Select(pair => pair.Value.FlushAsync()));
         }
 
         public IEntity SpawnFallingBlock(VectorF position, Material mat)

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -529,11 +529,13 @@ namespace Obsidian.WorldData
 
         public async Task FlushRegionsAsync()
         {
-            await Task.Run(() =>
-            {
-                Server.BroadcastMessage("Saving to disk...");
-                Parallel.ForEach(Regions.Values, async r => await r.FlushAsync());
-                Server.BroadcastMessage("Save complete.");
+            await Task.WhenAll(new List<Task> {
+                Task.Run(() =>
+                {
+                    Server.BroadcastMessage("Saving to disk...");
+                    Parallel.ForEach(Regions.Values, async r => await r.FlushAsync());
+                    Server.BroadcastMessage("Save complete.");
+                })
             });
         }
 

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -529,14 +529,7 @@ namespace Obsidian.WorldData
 
         public async Task FlushRegionsAsync()
         {
-            await Task.WhenAll(new List<Task> {
-                Task.Run(() =>
-                {
-                    Server.BroadcastMessage("Saving to disk...");
-                    Parallel.ForEach(Regions.Values, async r => await r.FlushAsync());
-                    Server.BroadcastMessage("Save complete.");
-                })
-            });
+            await Task.WhenAll(Regions.Values.Select(r => r.FlushAsync()));
         }
 
         public IEntity SpawnFallingBlock(VectorF position, Material mat)

--- a/SamplePlugin/SamplePlugin.cs
+++ b/SamplePlugin/SamplePlugin.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace SamplePlugin
 {
-    [Plugin(Name = "Sample Plugin", Version = "1.0",
-            Authors = "Obsidian Team", Description = "My sample plugin.",
-            ProjectUrl = "https://github.com/Naamloos/Obsidian")]
+    [Plugin("Sample Plugin", "1.0",
+            "Obsidian Team", "My sample plugin.",
+            "https://github.com/Naamloos/Obsidian")]
     public class SamplePlugin : PluginBase
     {
         // Any interface from Obsidian.Plugins.Services can be injected into properties
@@ -19,7 +19,7 @@ namespace SamplePlugin
         // Dependencies will be injected automatically, if dependency class and field/property names match
         // Plugins won't load until all their required dependencies are added
         // Optional dependencies may be injected at any time, if at all
-        [Dependency(MinVersion = "2.0", Optional = true), Alias("Sample Remote Plugin")]
+        [Dependency("2.0", true), Alias("Sample Remote Plugin")]
         public MyWrapper SampleRemotePlugin { get; set; }
 
         // One of server messages, called when an event occurs

--- a/SamplePlugin/SamplePlugin.cs
+++ b/SamplePlugin/SamplePlugin.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace SamplePlugin
 {
-    [Plugin(name: "Sample Plugin", version: "1.0",
-            authors: "Obsidian Team", description: "My sample plugin.",
-            projectUrl: "https://github.com/Naamloos/Obsidian")]
+    [Plugin(name: "Sample Plugin", Version = "1.0",
+            Authors = "Obsidian Team", Description = "My sample plugin.",
+            ProjectUrl = "https://github.com/Naamloos/Obsidian")]
     public class SamplePlugin : PluginBase
     {
         // Any interface from Obsidian.Plugins.Services can be injected into properties

--- a/SamplePlugin/SamplePlugin.cs
+++ b/SamplePlugin/SamplePlugin.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace SamplePlugin
 {
-    [Plugin("Sample Plugin", "1.0",
-            "Obsidian Team", "My sample plugin.",
-            "https://github.com/Naamloos/Obsidian")]
+    [Plugin(name: "Sample Plugin", version: "1.0",
+            authors: "Obsidian Team", description: "My sample plugin.",
+            projectUrl: "https://github.com/Naamloos/Obsidian")]
     public class SamplePlugin : PluginBase
     {
         // Any interface from Obsidian.Plugins.Services can be injected into properties
@@ -19,38 +19,38 @@ namespace SamplePlugin
         // Dependencies will be injected automatically, if dependency class and field/property names match
         // Plugins won't load until all their required dependencies are added
         // Optional dependencies may be injected at any time, if at all
-        [Dependency("2.0", true), Alias("Sample Remote Plugin")]
+        [Dependency(minVersion: "2.0", optional: true), Alias(identifier: "Sample Remote Plugin")]
         public MyWrapper SampleRemotePlugin { get; set; }
 
         // One of server messages, called when an event occurs
         public void OnLoad(IServer server)
         {
-            Logger.Log($"§a{Info.Name} §floaded! Hello §a{server.DefaultWorld.Name}§f!");
-            Logger.Log($"Hello! I live at §a{FileReader.CreateWorkingDirectory()}§f!");
+            Logger.Log(message: $"§a{Info.Name} §floaded! Hello §a{server.DefaultWorld.Name}§f!");
+            Logger.Log(message: $"Hello! I live at §a{FileReader.CreateWorkingDirectory()}§f!");
         }
 
         public void OnPermissionRevoked(PermissionRevokedEventArgs args)
         {
-            Logger.Log($"Permission {args.Permission} revoked from player {args.Player.Username}");
+            Logger.Log(message: $"Permission {args.Permission} revoked from player {args.Player.Username}");
         }
 
         public void OnPermissionGranted(PermissionGrantedEventArgs args)
         {
-            Logger.Log($"Permission {args.Permission} granted to player {args.Player.Username}");
+            Logger.Log(message: $"Permission {args.Permission} granted to player {args.Player.Username}");
         }
 
         public async Task OnPlayerJoin(PlayerJoinEventArgs playerJoinEvent)
         {
             var player = playerJoinEvent.Player;
 
-            await player.SendMessageAsync(ChatMessage.Simple($"Welcome {player.Username}!", ChatColor.Gold));
+            await player.SendMessageAsync(message: ChatMessage.Simple(text: $"Welcome {player.Username}!", color: ChatColor.Gold));
         }
 
-        [Command("plugincommand")]
-        [CommandInfo("woop dee doo this command is from within a plugin class!!")]
+        [Command(commandName: "plugincommand")]
+        [CommandInfo(description: "woop dee doo this command is from within a plugin class!!")]
         public async Task PluginCommandAsync(CommandContext ctx)
         {
-            await ctx.Sender.SendMessageAsync("Hello from plugin command implemented in Plugin class!");
+            await ctx.Sender.SendMessageAsync(message: "Hello from plugin command implemented in Plugin class!");
         }
     }
 


### PR DESCRIPTION
Have done some clean-up within the code to remove compiler warnings.

I have implemented constructors where I can and ignore warnings as a last resort. In some cases we need to make sure where we don't allow NULL we have only constructors for that model, otherwise more NULL checking needs to happen within the code.

Outstanding Warnings:
- 3692 relate to XML out of the 3708
- 16 are other warnings

Relates to issue: #163 