### PR TITLE
Implement Basic Version of PaperMC Patch 0284

### DIFF
--- a/Obsidian/Entities/Entity.cs
+++ b/Obsidian/Entities/Entity.cs
@@ -169,13 +169,27 @@ namespace Obsidian.Entities
 
         public void UpdatePosition(VectorF pos, bool onGround = true)
         {
-            this.Position = pos;
+            using (Chunk chunk = this.World.GetChunk(pos.X / 16f, pos.Y / 16f, false))
+            {
+                if (chunk != null && chunk.isGenerated)
+                {
+                    this.Position = pos;
+                }
+            }
+            
             this.OnGround = onGround;
         }
 
         public void UpdatePosition(VectorF pos, Angle yaw, Angle pitch, bool onGround = true)
         {
-            this.Position = pos;
+            using (Chunk chunk = this.World.GetChunk(pos.X / 16f, pos.Y / 16f, false))
+            {
+                if (chunk != null && chunk.isGenerated)
+                {
+                    this.Position = pos;
+                }
+            }
+
             this.Yaw = yaw;
             this.Pitch = pitch;
             this.OnGround = onGround;
@@ -183,8 +197,7 @@ namespace Obsidian.Entities
 
         public void UpdatePosition(float x, float y, float z, bool onGround = true)
         {
-            this.Position = new VectorF(x, y, z);
-            this.OnGround = onGround;
+            this.UpdatePosition(new VectorF(x, y, z), onGround);
         }
 
         public void UpdatePosition(Angle yaw, Angle pitch, bool onGround = true)

--- a/Obsidian/Entities/Entity.cs
+++ b/Obsidian/Entities/Entity.cs
@@ -169,12 +169,10 @@ namespace Obsidian.Entities
 
         public void UpdatePosition(VectorF pos, bool onGround = true)
         {
-            using (Chunk chunk = this.World.GetChunk(pos.X / 16f, pos.Y / 16f, false))
+            Chunk chunk = this.World.GetChunk((int)MathF.Round(pos.X / 16f), (int)MathF.Round(pos.Y / 16f), false);
+            if (chunk != null && chunk.isGenerated)
             {
-                if (chunk != null && chunk.isGenerated)
-                {
-                    this.Position = pos;
-                }
+                this.Position = pos;
             }
             
             this.OnGround = onGround;
@@ -182,12 +180,10 @@ namespace Obsidian.Entities
 
         public void UpdatePosition(VectorF pos, Angle yaw, Angle pitch, bool onGround = true)
         {
-            using (Chunk chunk = this.World.GetChunk(pos.X / 16f, pos.Y / 16f, false))
+            Chunk chunk = this.World.GetChunk((int)MathF.Round(pos.X / 16f), (int)MathF.Round(pos.Y / 16f), false);
+            if (chunk != null && chunk.isGenerated)
             {
-                if (chunk != null && chunk.isGenerated)
-                {
-                    this.Position = pos;
-                }
+                this.Position = pos;
             }
 
             this.Yaw = yaw;


### PR DESCRIPTION
Patch 0284 Prevents Players from moving into unloaded Chunks
I did this in Entity.cs so all Entities cannot move into unloaded Chunks

I havent tested it yet because its 23:30 and i wanna sleep, I can test this tomorrow but in my head it has a chance of **_atleast_** 20% of working

Feel free to reject this PR if yall wanna go with a patch-like System like Czompi proposed or ... if the code is just shit i guess