### PR TITLE
Feature/dotnet6

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -25,5 +25,5 @@ jobs:
       uses: actions/upload-artifact@v2.2.4
       with:
         name: Obsidian-Nightly-Build
-        path: /home/runner/work/Obsidian/Obsidian/Obsidian/bin/Debug/net5.0/
+        path: /home/runner/work/Obsidian/Obsidian/Obsidian/bin/Debug/net6.0/
       if: ${{ github.event_name == 'push' }} # Only upload artifacts on push, don't upload them for PRs

--- a/Obsidian.API/Obsidian.API.csproj
+++ b/Obsidian.API/Obsidian.API.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Obsidian.API</AssemblyName>
     <RootNamespace>Obsidian.API</RootNamespace>

--- a/Obsidian.API/Obsidian.API.csproj
+++ b/Obsidian.API/Obsidian.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Obsidian.API</AssemblyName>

--- a/Obsidian.API/Obsidian.API.csproj
+++ b/Obsidian.API/Obsidian.API.csproj
@@ -16,8 +16,9 @@
     <RepositoryUrl>https://github.com/ObsidianServer/Obsidian</RepositoryUrl>
     <PackageTags>minecraft obsidian api plugin plugins</PackageTags>
     <PackageIconUrl>https://i.imgur.com/jU1lkP4.png</PackageIconUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>../LICENSE</PackageLicenseFile>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Obsidian.API/Obsidian.API.csproj
+++ b/Obsidian.API/Obsidian.API.csproj
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/ObsidianServer/Obsidian</RepositoryUrl>
     <PackageTags>minecraft obsidian api plugin plugins</PackageTags>
     <PackageIconUrl>https://i.imgur.com/jU1lkP4.png</PackageIconUrl>
-    <PackageLicenseFile>../LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>

--- a/Obsidian.ConversionUtility/Obsidian.ConversionUtility.csproj
+++ b/Obsidian.ConversionUtility/Obsidian.ConversionUtility.csproj
@@ -9,7 +9,6 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Product>Obsidian Conversion Utility</Product>
     <Company>Obsidian Team</Company>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Obsidian.ConversionUtility/Obsidian.ConversionUtility.csproj
+++ b/Obsidian.ConversionUtility/Obsidian.ConversionUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Craftplacer</Authors>
     <Description>Converts Minecraft vanilla server files to JSON/Obsidian ones</Description>
     <RepositoryUrl>https://github.com/Naamloos/Obsidian</RepositoryUrl>

--- a/Obsidian.Nbt/Obsidian.Nbt.csproj
+++ b/Obsidian.Nbt/Obsidian.Nbt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/Obsidian.Nbt/Obsidian.Nbt.csproj
+++ b/Obsidian.Nbt/Obsidian.Nbt.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Obsidian.Tests/Nbt.cs
+++ b/Obsidian.Tests/Nbt.cs
@@ -1,9 +1,7 @@
-﻿using ICSharpCode.SharpZipLib.GZip;
-using Obsidian.API;
+﻿using Obsidian.API;
 using Obsidian.Nbt;
 using Obsidian.Net;
 using Obsidian.Utilities.Registry;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -25,12 +23,8 @@ namespace Obsidian.Tests
         public void BigTest()
         {
             var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("Obsidian.Tests.Assets.bigtest.nbt");
-            var decompressedStream = new MemoryStream();
 
-            GZip.Decompress(fs, decompressedStream, false);
-
-            decompressedStream.Position = 0;
-            var reader = new NbtReader(decompressedStream);
+            var reader = new NbtReader(fs, NbtCompression.GZip);
 
             var main = reader.ReadNextTag() as NbtCompound;
 

--- a/Obsidian.Tests/Obsidian.Tests.csproj
+++ b/Obsidian.Tests/Obsidian.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Obsidian.Tests/Obsidian.Tests.csproj
+++ b/Obsidian.Tests/Obsidian.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
-
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -60,12 +60,10 @@
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="sharpcompress" Version="0.29.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="SharpNoise" Version="0.12.1.1" />
-    <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -16,11 +16,12 @@
     <Company>Obsidian Team</Company>
     <Authors>Obsidian Team</Authors>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <Description>A C# implementation of the Minecraft server protocol (.NET 5)</Description>
-    <PackageProjectUrl>https://github.com/ObsidianServer/Obsidian</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/ObsidianServer/Obsidian</RepositoryUrl>
+    <Description>A C# implementation of the Minecraft server protocol (.NET 6)</Description>
+    <PackageProjectUrl>https://github.com/ObsidianMC/Obsidian</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ObsidianMC/Obsidian</RepositoryUrl>
     <PackageTags>minecraft-server-protocol minecraft-server minecraft</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>E:\GitHub\Obsidian\LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,10 @@
     <None Include="..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -20,7 +20,7 @@
     <PackageProjectUrl>https://github.com/ObsidianMC/Obsidian</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ObsidianMC/Obsidian</RepositoryUrl>
     <PackageTags>minecraft-server-protocol minecraft-server minecraft</PackageTags>
-    <PackageLicenseFile>E:\GitHub\Obsidian\LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>..\LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -20,7 +20,7 @@
     <PackageProjectUrl>https://github.com/ObsidianMC/Obsidian</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ObsidianMC/Obsidian</RepositoryUrl>
     <PackageTags>minecraft-server-protocol minecraft-server minecraft</PackageTags>
-    <PackageLicenseFile>..\LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![.NET Build](https://github.com/ObsidianMC/Obsidian/actions/workflows/dotnet.yml/badge.svg)](https://github.com/ObsidianMC/Obsidian/actions/workflows/dotnet.yml)
 [![Discord](https://img.shields.io/discord/772894170451804220.svg)](https://discord.gg/gQBtqyXChu)
 
-Obsidian is a C# .NET 5 implementation of the Minecraft server protocol. Obsidian is currently still in development, and a lot of love and care is being put into the project!
+Obsidian is a C# .NET 6 implementation of the Minecraft server protocol. Obsidian is currently still in development, and a lot of love and care is being put into the project!
 
 Feel free to join our [Discord](https://discord.gg/gQBtqyXChu) if you're curious about the current state of the project, questions are always welcome!
 
@@ -36,9 +36,10 @@ Find out about plugin development [here](https://obsidian-mc.net/articles/plugin
 
 ## 🔥 Development builds
 Very early development builds are available over at the [GitHub Actions](https://github.com/ObsidianMC/Obsidian/actions) page for this repository.
-- Ensure you have .NET 5 installed
+- Ensure you have [.NET 6 Runtime](https://dotnet.microsoft.com/download/dotnet/6.0) installed
 - Find the latest `.NET Build` action and scroll to the bottom of the page to find the artifacts.
 - Unzip the artifact and run `dotnet Obsidian.dll` to start the server.
+- On first run, a config file is generated. Fill this file with your preferenced values and run the previous command again.
 Easy, isn't it?
 
 ## 😎 The Obsidian Team

--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -5,7 +5,6 @@
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <OutputType>Library</OutputType>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
This PR updates all packages to use .NET 6 (apart from source generators, which are .NET Standard 2.0 for some reason (@Seb-stian why exactly is this?)

🎉 Other issues remaining under the .NET 6 upgrade are still open, as this is simply a framework update.

As this is a very minor PR, and I've already confirmed obsidian still runs _fine_ after this, I don't think more than 1 reviewer is needed for merging this one.