### PR TITLE
Cleanup MinecraftAPI.cs

### DIFF
--- a/Obsidian/Utilities/Mojang/MinecraftAPI.cs
+++ b/Obsidian/Utilities/Mojang/MinecraftAPI.cs
@@ -1,49 +1,44 @@
-﻿using System.Net.Http;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text;
-using System.Text.Json;
 using System.Web;
 
 namespace Obsidian.Utilities.Mojang;
 
 public class MinecraftAPI
 {
-    private static readonly HttpClient Http = Globals.HttpClient;
+    private static readonly HttpClient httpClient = new();
 
-    public static async Task<List<MojangUser>> GetUsersAsync(string[] usernames)
+    public static async Task<List<MojangUser>?> GetUsersAsync(params string[] usernames)
     {
-        var escaped_usernames = new List<string>();
-
+        List<string> escapedUsernames = new();
         for (int i = 0; i < usernames.Length; i++)
-            escaped_usernames.Add(HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(usernames[i])));
+        {
+            escapedUsernames.Add(HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(usernames[i])));
+        }
 
-        using HttpResponseMessage response = await Http.PostAsync("https://api.mojang.com/profiles/minecraft", new StringContent(JsonSerializer.Serialize(escaped_usernames), Encoding.UTF8, "application/json"));
-
-        return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<List<MojangUser>>() : null;
+        using HttpResponseMessage response = await httpClient.PostAsJsonAsync("https://api.mojang.com/profiles/minecraft", escapedUsernames);
+        return response.IsSuccessStatusCode ? (await response.Content.ReadFromJsonAsync<List<MojangUser>>()) : null;
     }
 
-    public static async Task<MojangUser> GetUserAsync(string username)
+    public static async Task<MojangUser?> GetUserAsync(string username)
     {
-        var escaped_username = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
-        var users = await GetUsersAsync(new[] { escaped_username });
+        string escapedUsername = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
+        List<MojangUser>? users = await GetUsersAsync(escapedUsername);
 
         return (users == null || users.Count <= 0) ? null : users.FirstOrDefault();
     }
 
-    public static async Task<MojangUser> GetUserAndSkinAsync(string uuid)
+    public static async Task<MojangUser?> GetUserAndSkinAsync(string uuid)
     {
-        var escaped_uuid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(uuid));
-        // I'm fairly sure this is not exploitable, but good practice and consistency are two important factors imo
-        using HttpResponseMessage response = await Http.GetAsync("https://sessionserver.mojang.com/session/minecraft/profile/" + escaped_uuid);
-
-        return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<MojangUser>() : null;
+        string escapedUuid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(uuid));
+        return await httpClient.GetFromJsonAsync<MojangUser>($"https://sessionserver.mojang.com/session/minecraft/profile/{escapedUuid}");
     }
 
-    public static async Task<JoinedResponse> HasJoined(string username, string serverId)
+    public static async Task<JoinedResponse?> HasJoined(string username, string serverId)
     {
-        var escaped_username = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
-        var escaped_serverid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(serverId));
-        using HttpResponseMessage response = await Http.GetAsync($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={escaped_username}&serverId={escaped_serverid}");
-
-        return response.IsSuccessStatusCode ? (await response.Content.ReadAsStringAsync()).FromJson<JoinedResponse>() : null;
+        string escapedUsername = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
+        string escapedServerId = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(serverId));
+        return await httpClient.GetFromJsonAsync<JoinedResponse>($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={escapedUsername}&serverId={escapedServerId}");
     }
 }

--- a/Obsidian/Utilities/Mojang/MinecraftAPI.cs
+++ b/Obsidian/Utilities/Mojang/MinecraftAPI.cs
@@ -18,27 +18,26 @@ public class MinecraftAPI
         }
 
         using HttpResponseMessage response = await httpClient.PostAsJsonAsync("https://api.mojang.com/profiles/minecraft", escapedUsernames);
-        return response.IsSuccessStatusCode ? (await response.Content.ReadFromJsonAsync<List<MojangUser>>()) : null;
+        return response.IsSuccessStatusCode ? (await response.Content.ReadFromJsonAsync<List<MojangUser>>(Globals.JsonOptions)) : null;
     }
 
     public static async Task<MojangUser?> GetUserAsync(string username)
     {
         string escapedUsername = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
         List<MojangUser>? users = await GetUsersAsync(escapedUsername);
-
-        return (users == null || users.Count <= 0) ? null : users.FirstOrDefault();
+        return users?.FirstOrDefault();
     }
 
     public static async Task<MojangUser?> GetUserAndSkinAsync(string uuid)
     {
         string escapedUuid = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(uuid));
-        return await httpClient.GetFromJsonAsync<MojangUser>($"https://sessionserver.mojang.com/session/minecraft/profile/{escapedUuid}");
+        return await httpClient.GetFromJsonAsync<MojangUser>($"https://sessionserver.mojang.com/session/minecraft/profile/{escapedUuid}", Globals.JsonOptions);
     }
 
     public static async Task<JoinedResponse?> HasJoined(string username, string serverId)
     {
         string escapedUsername = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(username));
         string escapedServerId = HttpUtility.UrlEncode(Encoding.UTF8.GetBytes(serverId));
-        return await httpClient.GetFromJsonAsync<JoinedResponse>($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={escapedUsername}&serverId={escapedServerId}");
+        return await httpClient.GetFromJsonAsync<JoinedResponse>($"https://sessionserver.mojang.com/session/minecraft/hasJoined?username={escapedUsername}&serverId={escapedServerId}", Globals.JsonOptions);
     }
 }

--- a/Obsidian/Utilities/Mojang/MinecraftAPI.cs
+++ b/Obsidian/Utilities/Mojang/MinecraftAPI.cs
@@ -7,7 +7,7 @@ namespace Obsidian.Utilities.Mojang;
 
 public class MinecraftAPI
 {
-    private static readonly HttpClient httpClient = new();
+    private static readonly HttpClient httpClient = Globals.HttpClient;
 
     public static async Task<List<MojangUser>?> GetUsersAsync(params string[] usernames)
     {


### PR DESCRIPTION
Cleans up MinecraftAPI.cs by using the Json extension methods. Additionally marks some return types as nullable