### PR TITLE
Improved Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+.gitignore
+appveyor.yml
+azure-pipelines.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-# Build Obsidian first
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-sdk
-WORKDIR /work
-COPY ../ ./
-RUN dotnet publish Obsidian/Obsidian.csproj -c Debug -o build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet publish Obsidian/ -c Release -r linux-musl-x64 --self-contained -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:EnableCompressionInSingleFile=true -p:DebugType=embedded
 
-# Build image
-FROM mcr.microsoft.com/dotnet/runtime:6.0
-WORKDIR /obsidian
-COPY --from=build-sdk /work/build .
-EXPOSE 25565/TCP
-VOLUME "/files"
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /src/Obsidian/bin/Release/net6.0/linux-musl-x64/publish/ .
+RUN apk upgrade --update-cache --available && apk add openssl libstdc++ && rm -rf /var/cache/apk/*
 
-# Define entry
-ENTRYPOINT ["dotnet", "Obsidian.dll", "/files"]
+WORKDIR /files
+ENTRYPOINT DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 /app/Obsidian

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feel free to join our [Discord](https://discord.gg/gQBtqyXChu) if you're curious
 - [ ] Redstone circuits
 
 ## 💻 Contribute
-Contributions are always welcome! 
+Contributions are always welcome!
 Read about how you can contribute [here](https://github.com/ObsidianMC/Documentation/blob/master/articles/contrib.md)
 
 ## 🔌 Develop plugins
@@ -46,12 +46,20 @@ Easy, isn't it?
 You can now run Obsidian using Docker! As of right now, no image is available on DockerHub yet, but it will be sometime soon.
 
 For now, to run Obsidian on Docker you will have to follow the following steps:
-1. Clone Obsidian`git clone https://github.com/ObsidianMC/Obsidian.git`
+1. Clone Obsidian `git clone https://github.com/ObsidianMC/Obsidian.git`
 2. Go to Obsidian's cloned directory `cd Obsidian`
 3. Build the docker image `docker build . -t obsidian`
 4. Run the container `docker run -d -p YOUR_HOST_PORT:25565 -v YOUR_SERVERFILES_PATH:/files --name YOUR_CONTAINER_NAME obsidian`
 5. Obsidian will pregenerate a config file. Fill it out in `YOUR_SERVERFILES_PATH/config.json`
 6. Start Obsidian's container again. `docker restart YOUR_CONTAINER_NAME`
+
+### Docker Compose
+There's also docker-compose support.
+1. Clone Obsidian `git clone https://github.com/ObsidianMC/Obsidian.git`
+2. Go to Obsidian's cloned directory `cd Obsidian`
+3. Run `docker-compose up -V` to generate the `config.json`
+4. Edit your `docker-compose.yml` file, along with `files/config.json`
+5. `docker-compose up -Vd` to have the server run! The world, plugin and other server related files will be created in the `files` directory.
 
 ## 😎 The Obsidian Team
 - [Naamloos](https://github.com/Naamloos) (creator)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9" # Docker compose version, NOT project version
+
+services:
+  obsidian:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "25565:25565"
+    volumes:
+      - "${PWD}/files:/files"


### PR DESCRIPTION
- Shrinks the image size from 207MB to 58.7MB
- Adds a `docker-compose.yml` file, along with a `.dockerignore` file
- Turns the output to a single file executable, located in `/app/Obsidian`
