### PR TITLE
[Closed due to rework] Add some client and serverbound packets

### DIFF
--- a/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
+++ b/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
@@ -24,6 +24,7 @@ public sealed class RegistryAssetsGenerator : ISourceGenerator
         ParseItems(GetJson("items.json"), source);
         ParseRecipes(GetJson("recipes.json"), source);
         ParseTags(GetJson("tags.json"), source);
+        ParsePacketDebug(GetJson("packet_debug.json"), source);
 
         source.EndScope(); // EOF type
         source.EndScope(); // EOF namespace
@@ -67,6 +68,11 @@ public sealed class RegistryAssetsGenerator : ISourceGenerator
     }
 
     private static void ParseTags(string json, CodeBuilder source)
+    {
+
+    }
+    
+    private static void ParsePacketDebug(string json, CodeBuilder source)
     {
 
     }

--- a/Obsidian/Assets/packet_debug.json
+++ b/Obsidian/Assets/packet_debug.json
@@ -1,0 +1,992 @@
+[
+  {
+    "state": "Handshaking",
+    "bound_to": "Server",
+    "id": "0x00",
+    "name": "Handshake"
+  },
+  {
+    "state": "Status",
+    "bound_to": "Client",
+    "id": "0x00",
+    "name": "StatusReponse"
+  },
+  {
+    "state": "Status",
+    "bound_to": "Client",
+    "id": "0x01",
+    "name": "StatusPong"
+  },
+  {
+    "state": "Status",
+    "bound_to": "Server",
+    "id": "0x00",
+    "name": "StatusRequest"
+  },
+  {
+    "state": "Status",
+    "bound_to": "Server",
+    "id": "0x01",
+    "name": "StatusPing"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Client",
+    "id": "0x00",
+    "name": "Disconnect"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Client",
+    "id": "0x01",
+    "name": "EncryptionRequest"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Client",
+    "id": "0x02",
+    "name": "LoginSuccess"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Client",
+    "id": "0x03",
+    "name": "SetCompression"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Client",
+    "id": "0x04",
+    "name": "LoginPluginRequest"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Server",
+    "id": "0x00",
+    "name": "LoginStart"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Server",
+    "id": "0x01",
+    "name": "EncryptionResponse"
+  },
+  {
+    "state": "Login",
+    "bound_to": "Server",
+    "id": "0x02",
+    "name": "LoginPluginResponse"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x00",
+    "name": "SpawnEntity"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x01",
+    "name": "SpawnExperienceOrb"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x02",
+    "name": "SpawnLivingEntity"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x03",
+    "name": "SpawnPainting"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x04",
+    "name": "SpawnPlayer"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x05",
+    "name": "SculkVibrationSignal"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x06",
+    "name": "EntityAnimation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x07",
+    "name": "Statistics"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x08",
+    "name": "AcknowledgePlayerDigging"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x09",
+    "name": "BlockBreakAnimation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0A",
+    "name": "BlockEntityData"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0B",
+    "name": "BlockAction"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0C",
+    "name": "BlockChange"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0D",
+    "name": "BossBar"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0E",
+    "name": "ServerDifficulty"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x0F",
+    "name": "ChatMessage"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x10",
+    "name": "ClearTitles"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x11",
+    "name": "Tab-Complete"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x12",
+    "name": "DeclareCommands"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x13",
+    "name": "CloseWindow"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x14",
+    "name": "WindowItems"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x15",
+    "name": "WindowProperty"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x16",
+    "name": "SetSlot"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x17",
+    "name": "SetCooldown"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x18",
+    "name": "PluginMessage"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x19",
+    "name": "NamedSoundEffect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1A",
+    "name": "Disconnect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1B",
+    "name": "EntityStatus"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1C",
+    "name": "Explosion"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1D",
+    "name": "UnloadChunk"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1E",
+    "name": "ChangeGameState"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x1F",
+    "name": "OpenHorseWindow"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x20",
+    "name": "InitializeWorldBorder"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x21",
+    "name": "KeepAlive"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x22",
+    "name": "ChunkDataAndUpdateLight"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x23",
+    "name": "Effect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x24",
+    "name": "Particle"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x25",
+    "name": "UpdateLight"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x26",
+    "name": "JoinGame"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x27",
+    "name": "MapData"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x28",
+    "name": "TradeList"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x29",
+    "name": "EntityPosition"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2A",
+    "name": "EntityPositionAndRotation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2B",
+    "name": "EntityRotation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2C",
+    "name": "VehicleMove"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2D",
+    "name": "OpenBook"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2E",
+    "name": "OpenWindow"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x2F",
+    "name": "OpenSignEditor"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x30",
+    "name": "Ping"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x31",
+    "name": "CraftRecipeResponse"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x32",
+    "name": "PlayerAbilities"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x33",
+    "name": "EndCombatEvent"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x34",
+    "name": "EnterCombatEvent"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x35",
+    "name": "DeathCombatEvent"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x36",
+    "name": "PlayerInfo"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x37",
+    "name": "FacePlayer"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x38",
+    "name": "PlayerPositionAndLook"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x39",
+    "name": "UnlockRecipes"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3A",
+    "name": "DestroyEntities"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3B",
+    "name": "RemoveEntityEffect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3C",
+    "name": "ResourcePackSend"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3D",
+    "name": "Respawn"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3E",
+    "name": "EntityHeadLook"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x3F",
+    "name": "MultiBlockChange"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x40",
+    "name": "SelectAdvancementTab"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x41",
+    "name": "ActionBar"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x42",
+    "name": "WorldBorderCenter"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x43",
+    "name": "WorldBorderLerpSize"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x44",
+    "name": "WorldBorderSize"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x45",
+    "name": "WorldBorderWarningDelay"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x46",
+    "name": "WorldBorderWarningReach"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x47",
+    "name": "Camera"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x48",
+    "name": "HeldItemChange"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x49",
+    "name": "UpdateViewPosition"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4A",
+    "name": "UpdateViewDistance"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4B",
+    "name": "SpawnPosition"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4C",
+    "name": "Display Scoreboard"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4D",
+    "name": "EntityMetadata"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4E",
+    "name": "AttachEntity"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x4F",
+    "name": "EntityVelocity"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x50",
+    "name": "EntityEquipment"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x51",
+    "name": "SetExperience"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x52",
+    "name": "UpdateHealth"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x53",
+    "name": "ScoreboardObjective"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x54",
+    "name": "SetPassengers"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x55",
+    "name": "Teams"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x56",
+    "name": "UpdateScore"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x57",
+    "name": "UpdateSimulationDistance"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x58",
+    "name": "SetTitleSubTitle"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x59",
+    "name": "TimeUpdate"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5A",
+    "name": "SetTitleText"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5B",
+    "name": "SetTitleTimes"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5C",
+    "name": "EntitySoundEffect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5D",
+    "name": "Sound Effect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5E",
+    "name": "StopSound"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x5F",
+    "name": "PlayerListHeaderAndFooter"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x60",
+    "name": "NbtQueryResponse"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x61",
+    "name": "CollectItem"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x62",
+    "name": "EntityTeleport"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x63",
+    "name": "Advancements"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x64",
+    "name": "EntityProperties"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x65",
+    "name": "EntityEffect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x66",
+    "name": "DeclareRecipes"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Client",
+    "id": "0x67",
+    "name": "Tags"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x00",
+    "name": "TeleportConfirm"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x01",
+    "name": "QueryBlockNBT"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x02",
+    "name": "SetDifficulty"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x03",
+    "name": "IncomingChatMessage"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x04",
+    "name": "ClientStatus"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x05",
+    "name": "ClientSettings"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x06",
+    "name": "TabComplete"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x07",
+    "name": "ClickWindowButton"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x08",
+    "name": "ClickWindow"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x09",
+    "name": "CloseWindow"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0A",
+    "name": "PluginMessage"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0B",
+    "name": "EditBook"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0C",
+    "name": "QueryEntityNbt"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0D",
+    "name": "InteractEntity"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0E",
+    "name": "ServerDifficulty"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x0F",
+    "name": "KeepAlive"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x10",
+    "name": "LockDifficulty"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x11",
+    "name": "PlayerPosition"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x12",
+    "name": "PlayerPositionAndRotation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x13",
+    "name": "PlayerRotation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x14",
+    "name": "PlayerMovement"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x15",
+    "name": "VehicleMove"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x16",
+    "name": "SteerBoat"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x17",
+    "name": "PickItem"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x18",
+    "name": "CraftRecipeRequest"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x19",
+    "name": "PlayerAbilities"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1A",
+    "name": "PlayerDigging"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1B",
+    "name": "EntityAction"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1C",
+    "name": "SteerVehicle"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1D",
+    "name": "Pong"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1E",
+    "name": "SetRecipeBookState"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x1F",
+    "name": "SetDisplayedRecipe"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x20",
+    "name": "NameItem"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x21",
+    "name": "ResourcePackStatus"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x22",
+    "name": "AdvancementTab"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x23",
+    "name": "SelectTrade"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x24",
+    "name": "SetBeaconEffect"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x25",
+    "name": "HeldItemChange"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x26",
+    "name": "UpdateCommandBlock"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x27",
+    "name": "UpdateCommandBlockMinecart"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x28",
+    "name": "CreativeInventoryAction"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x29",
+    "name": "UpdateJigsawBlock"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2A",
+    "name": "AnimationPacket"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2B",
+    "name": "UpdateSign"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2C",
+    "name": "Animation"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2D",
+    "name": "Spectate"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2E",
+    "name": "PlayerBlockPlacement"
+  },
+  {
+    "state": "Play",
+    "bound_to": "Server",
+    "id": "0x2F",
+    "name": "UseItem"
+  }
+]

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -289,7 +289,7 @@ public class Client : IDisposable
                     }
                     break;
             }
-
+            //Globals.PacketLogger.LogDebug(Globals.PacketDebugHandler.GetPacket(State, PacketType.Server, id));
             //await Task.Delay(50);
         }
 

--- a/Obsidian/Globals.cs
+++ b/Obsidian/Globals.cs
@@ -12,6 +12,7 @@ public static class Globals
     public static HttpClient HttpClient { get; } = new();
     public static XorshiftRandom Random { get; } = new();
     public static ILogger PacketLogger { get; set; }
+    internal static PacketDebugHandler PacketDebugHandler { get; set; }
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -1206,4 +1206,20 @@ public partial class MinecraftStream
         WriteBoolean(matchItem.HasTooltip);
         if (matchItem.HasTooltip && matchItem.Tooltip is not null) WriteChat(matchItem.Tooltip);
     }
+
+    [WriteMethod]
+    public async void WriteTrade(Trade trade)
+    {
+        await WriteSlotAsync(trade.InputItem1);
+        await WriteSlotAsync(trade.OutputItem);
+        WriteBoolean(trade.HasSecondItem);
+        if (trade.HasSecondItem && trade.InputItem2 is not null) await WriteSlotAsync(trade.InputItem2);
+        WriteBoolean(trade.TradeDisabled);
+        WriteInt(trade.NumberOfTradeUses);
+        WriteInt(trade.MaximumNumberOfTradeUses);
+        WriteInt(trade.Xp);
+        WriteInt(trade.SpecialPrice);
+        WriteFloat(trade.PriceMultiplier);
+        WriteInt(trade.Demand);
+    }
 }

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -1198,4 +1198,12 @@ public partial class MinecraftStream
                 break;
         }
     }
+
+    [WriteMethod]
+    public void WriteMatchItem(MatchItem matchItem)
+    {
+        WriteString(matchItem.Match);
+        WriteBoolean(matchItem.HasTooltip);
+        if (matchItem.HasTooltip && matchItem.Tooltip is not null) WriteChat(matchItem.Tooltip);
+    }
 }

--- a/Obsidian/Net/Packets/Login/LoginPluginRequest.cs
+++ b/Obsidian/Net/Packets/Login/LoginPluginRequest.cs
@@ -1,0 +1,19 @@
+﻿using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Login;
+
+public partial class LoginPluginRequest : IClientboundPacket
+{
+    [Field(0), VarLength]
+    public int MessageId { get; set; }
+    
+    [Field(1)]
+    public string Channel { get; set; }
+    
+    [Field(2)]
+    public byte[] Data { get; set; }
+    
+    public int Id => 0x04;
+
+}

--- a/Obsidian/Net/Packets/Login/LoginPluginResponse.cs
+++ b/Obsidian/Net/Packets/Login/LoginPluginResponse.cs
@@ -1,0 +1,25 @@
+﻿using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Login;
+
+public partial class LoginPluginResponse : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int MessageId { get; set; }
+
+    [Field(1)]
+    public bool Successful { get; set; }
+
+    [Field(2)]
+    public byte[] Data { get; set; }
+
+    public int Id => 0x04;
+
+    public ValueTask HandleAsync(Server server, Player player) => ValueTask.CompletedTask;
+}

--- a/Obsidian/Net/Packets/ObjectExtensions.cs
+++ b/Obsidian/Net/Packets/ObjectExtensions.cs
@@ -1,61 +1,5 @@
 ﻿namespace Obsidian.Net.Packets;
 
-internal class PackDict
-{
-
-    internal static Dictionary<string, string> PacketList = new()
-    {
-        { "0x00", "TeleportConfirm" },
-        { "0x01", "QueryBlockNBT" },
-        { "0x02", "SetDifficulty" },
-        { "0x03", "IncomingChatMessage" },
-        { "0x04", "ClientStatus" },
-        { "0x05", "ClientSettings" },
-        { "0x06", "TabComplete" },
-        { "0x07", "ClickWindowButton" },
-        { "0x08", "ClickWindow" },
-        { "0x09", "CloseWindow" },
-        { "0x0A", "PluginMessage" },
-        { "0x0B", "EditBook" },
-        { "0x0C", "QueryEntityNbt" },
-        { "0x0D", "InteractEntity" },
-        { "0x0E", "ServerDifficulty" },
-        { "0x0F", "GenerateStructure" },
-        { "0x10", "LockDifficulty" },
-        { "0x11", "PlayerPosition" },
-        { "0x12", "PlayerPositionAndRotation" },
-        { "0x13", "PlayerRotation" },
-        { "0x14", "PlayerMovement" },
-        { "0x15", "VehicleMove" },
-        { "0x16", "SteerBoat" },
-        { "0x17", "PickItem" },
-        { "0x18", "CraftRecipeRequest" },
-        { "0x19", "PlayerAbilities" },
-        { "0x1A", "PlayerDigging" },
-        { "0x1B", "EntityAction" },
-        { "0x1C", "SteerVehicle" },
-        { "0x1D", "Pong" },
-        { "0x1E", "SetRecipeBookState" },
-        { "0x1F", "SetDisplayedRecipe" },
-        { "0x20", "NameItem" },
-        { "0x21", "ResourcePackStatus" },
-        { "0x22", "AdvancementTab" },
-        { "0x23", "SelectTrade" },
-        { "0x24", "SetBeaconEffect" },
-        { "0x25", "HeldItemChange" },
-        { "0x26", "UpdateCommandBlock" },
-        { "0x27", "UpdateCommandBlockMinecart" },
-        { "0x28", "CreativeInventoryAction" },
-        { "0x29", "UpdateJigsawBlock" },
-        { "0x2A", "AnimationPacket" },
-        { "0x2B", "UpdateSign" },
-        { "0x2C", "Animation" },
-        { "0x2D", "Spectate" },
-        { "0x2E", "PlayerBlockPlacement" },
-        { "0x2F", "UseItem" }
-    };
-
-}
 internal static class ObjectExtensions
 {
     internal static string AsString(this object @this)
@@ -63,18 +7,5 @@ internal static class ObjectExtensions
         var type = @this.GetType();
 
         return $"{type.Name}{{{string.Join(", ", type.GetProperties().Select(x => $"{x.Name}=\"{x.GetValue(@this)}\""))}}}";
-    }
-    internal static string ToPacketName(this int @this)
-    {
-        string? value = null;
-        try
-        {
-            value = PackDict.PacketList[$"0x{@this:X2}"];
-        }
-        catch (Exception ex)
-        {
-        }
-
-        return $"{value ?? "UNDEFINED"} (0x{@this:X2})";
     }
 }

--- a/Obsidian/Net/Packets/ObjectExtensions.cs
+++ b/Obsidian/Net/Packets/ObjectExtensions.cs
@@ -47,7 +47,7 @@ internal class PackDict
         { "0x27", "UpdateCommandBlockMinecart" },
         { "0x28", "CreativeInventoryAction" },
         { "0x29", "UpdateJigsawBlock" },
-        { "0x2A", "UpdateStructureBlock" },
+        { "0x2A", "AnimationPacket" },
         { "0x2B", "UpdateSign" },
         { "0x2C", "Animation" },
         { "0x2D", "Spectate" },

--- a/Obsidian/Net/Packets/ObjectExtensions.cs
+++ b/Obsidian/Net/Packets/ObjectExtensions.cs
@@ -1,0 +1,80 @@
+﻿namespace Obsidian.Net.Packets;
+
+internal class PackDict
+{
+
+    internal static Dictionary<string, string> PacketList = new()
+    {
+        { "0x00", "TeleportConfirm" },
+        { "0x01", "QueryBlockNBT" },
+        { "0x02", "SetDifficulty" },
+        { "0x03", "IncomingChatMessage" },
+        { "0x04", "ClientStatus" },
+        { "0x05", "ClientSettings" },
+        { "0x06", "TabComplete" },
+        { "0x07", "ClickWindowButton" },
+        { "0x08", "ClickWindow" },
+        { "0x09", "CloseWindow" },
+        { "0x0A", "PluginMessage" },
+        { "0x0B", "EditBook" },
+        { "0x0C", "QueryEntityNbt" },
+        { "0x0D", "InteractEntity" },
+        { "0x0E", "ServerDifficulty" },
+        { "0x0F", "GenerateStructure" },
+        { "0x10", "LockDifficulty" },
+        { "0x11", "PlayerPosition" },
+        { "0x12", "PlayerPositionAndRotation" },
+        { "0x13", "PlayerRotation" },
+        { "0x14", "PlayerMovement" },
+        { "0x15", "VehicleMove" },
+        { "0x16", "SteerBoat" },
+        { "0x17", "PickItem" },
+        { "0x18", "CraftRecipeRequest" },
+        { "0x19", "PlayerAbilities" },
+        { "0x1A", "PlayerDigging" },
+        { "0x1B", "EntityAction" },
+        { "0x1C", "SteerVehicle" },
+        { "0x1D", "Pong" },
+        { "0x1E", "SetRecipeBookState" },
+        { "0x1F", "SetDisplayedRecipe" },
+        { "0x20", "NameItem" },
+        { "0x21", "ResourcePackStatus" },
+        { "0x22", "AdvancementTab" },
+        { "0x23", "SelectTrade" },
+        { "0x24", "SetBeaconEffect" },
+        { "0x25", "HeldItemChange" },
+        { "0x26", "UpdateCommandBlock" },
+        { "0x27", "UpdateCommandBlockMinecart" },
+        { "0x28", "CreativeInventoryAction" },
+        { "0x29", "UpdateJigsawBlock" },
+        { "0x2A", "UpdateStructureBlock" },
+        { "0x2B", "UpdateSign" },
+        { "0x2C", "Animation" },
+        { "0x2D", "Spectate" },
+        { "0x2E", "PlayerBlockPlacement" },
+        { "0x2F", "UseItem" }
+    };
+
+}
+internal static class ObjectExtensions
+{
+    internal static string AsString(this object @this)
+    {
+        var type = @this.GetType();
+
+        return $"{type.Name}{{{string.Join(", ", type.GetProperties().Select(x => $"{x.Name}=\"{x.GetValue(@this)}\""))}}}";
+    }
+    internal static string ToPacketName(this int @this)
+    {
+        string? value = null;
+        try
+        {
+            value = PackDict.PacketList[$"0x{@this:X2}"];
+        }
+        catch (Exception ex)
+        {
+        }
+
+        return $"{value ?? "UNDEFINED"} (0x{@this:X2})";
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/DeathCombatEvent.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/DeathCombatEvent.cs
@@ -1,0 +1,22 @@
+﻿using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+public partial class DeathCombatEvent :IClientboundPacket
+{
+    [Field(0), VarLength]
+    public int PlayerId { get; init; }
+
+    [Field(1)]
+    public int EntityId { get; init; }
+
+    [Field(2)]
+    public ChatMessage Message { get; init; }
+
+    public int Id => 0x35;
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/ServerDifficulty.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/ServerDifficulty.cs
@@ -7,11 +7,15 @@ public partial class ServerDifficulty : IClientboundPacket
 {
     [Field(0), ActualType(typeof(byte))]
     public Difficulty Difficulty { get; }
+    
+    [Field(1)]
+    public bool DifficultyLocked { get; }
 
     public int Id => 0x0E;
 
     public ServerDifficulty(Difficulty difficulty)
     {
         Difficulty = difficulty;
+        DifficultyLocked = true;
     }
 }

--- a/Obsidian/Net/Packets/Play/Clientbound/TabCompleteResponse.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/TabCompleteResponse.cs
@@ -1,0 +1,52 @@
+﻿using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+public partial class TabCompleteResponse : IClientboundPacket
+{
+    public TabCompleteResponse(int transactionId, int start, int length, int count, List<MatchItem> matches)
+    {
+        TransactionId = transactionId;
+        Start = start;
+        Length = length;
+        Count = count;
+        Matches = matches;
+    }
+
+    [Field(0), VarLength]
+    public int TransactionId { get; init; }
+    
+    [Field(1), VarLength]
+    public int Start { get; init; }
+    
+    [Field(2), VarLength]
+    public int Length { get; init; }
+
+    [Field(3), VarLength]
+    public int Count { get; init; }
+    
+    [Field(4)]
+    public List<MatchItem> Matches { get; init; }
+
+    public int Id => 0x11;
+    
+}
+
+public class MatchItem
+{
+    public MatchItem(string match, bool hasTooltip, ChatMessage? tooltip=null)
+    {
+        Match = match;
+        HasTooltip = hasTooltip;
+        Tooltip = tooltip;
+    }
+
+    public string Match { get; init; }
+    public bool HasTooltip { get; init; }
+    public ChatMessage? Tooltip { get; init; }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/TradeList.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/TradeList.cs
@@ -1,0 +1,102 @@
+﻿using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+public partial class TradeListPacket : IClientboundPacket
+{
+    public TradeListPacket(int windowId, sbyte size, List<Trade> trades, EVillagerLevel villagerLevel, int experience, bool isRegularVillager, bool canRestock)
+    {
+        WindowId = windowId;
+        Size = size;
+        Trades = trades;
+        VillagerLevel = villagerLevel;
+        Experience = experience;
+        IsRegularVillager = isRegularVillager;
+        CanRestock = canRestock;
+    }
+
+    [Field(0), VarLength]
+    public int WindowId { get; init; }
+
+    [Field(1)]
+    public sbyte Size { get; init; }
+
+    [Field(2)]
+    public List<Trade> Trades { get; init; }
+
+    [Field(3), ActualType(typeof(int)), VarLength]
+    public EVillagerLevel VillagerLevel { get; init; }
+
+    [Field(4), VarLength]
+    public int Experience { get; init; }
+    
+    [Field(5)]
+    public bool IsRegularVillager { get; init; }
+    
+    [Field(6)]
+    public bool CanRestock { get; init; }
+
+
+    public int Id => 0x28;
+
+}
+
+public class Trade
+{
+    public Trade()
+    {
+    }
+
+    public Trade(ItemStack inputItem1, ItemStack outputItem, bool hasSecondItem, ItemStack inputItem2, bool tradeDisabled, int numberOfTradeUses, int maximumNumberOfTradeUses, int xp, int specialPrice, float priceMultiplier, int demand): base()
+    {
+        InputItem1 = inputItem1;
+        OutputItem = outputItem;
+        HasSecondItem = hasSecondItem;
+        InputItem2 = inputItem2;
+        TradeDisabled = tradeDisabled;
+        NumberOfTradeUses = numberOfTradeUses;
+        MaximumNumberOfTradeUses = maximumNumberOfTradeUses;
+        Xp = xp;
+        SpecialPrice = specialPrice;
+        PriceMultiplier = priceMultiplier;
+        Demand = demand;
+    }
+
+    public ItemStack InputItem1 { get; init; }
+
+    public ItemStack OutputItem { get; init; }
+
+    public bool HasSecondItem { get; init; }
+
+    public ItemStack InputItem2 { get; init; }
+
+    public bool TradeDisabled { get; init; }
+
+    public int NumberOfTradeUses { get; init; }
+
+    public int MaximumNumberOfTradeUses { get; init; }
+
+    public int Xp { get; init; }
+
+    public int SpecialPrice { get; init; }
+
+    public float PriceMultiplier { get; init; }
+
+    public int Demand { get; init; }
+
+}
+
+public enum EVillagerLevel
+{
+    Novice = 1,
+    Apprentice = 2,
+    Journeyman = 3,
+    Expert = 4,
+    Master = 5
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/ERecipeBookType.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/ERecipeBookType.cs
@@ -1,0 +1,9 @@
+﻿namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public enum ERecipeBookType
+{
+    Crafting,
+    Furnace,
+    BlastFurnace,
+    Smoker
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/EditBook.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/EditBook.cs
@@ -12,7 +12,7 @@ public partial class EditBook : IServerboundPacket
     [Field(1), VarLength]
     public int Count { get; set; }
     
-    [Field(2)]
+    [Field(2), ActualType(typeof(string))]
     public List<string> Entries { get; set; }
     
     [Field(3)]

--- a/Obsidian/Net/Packets/Play/Serverbound/EditBook.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/EditBook.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class EditBook : IServerboundPacket
+{
+    [Field(0), VarLength, ActualType(typeof(int))]
+    public Hand Hand { get; set; }
+    
+    [Field(1), VarLength]
+    public int Count { get; set; }
+    
+    [Field(2)]
+    public List<string> Entries { get; set; }
+    
+    [Field(3)]
+    public bool HasTitle { get; set; }
+    
+    [Field(4)]
+    public string Title { get; set; }
+
+    public int Id => 0x15;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/GenerateStructure.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/GenerateStructure.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class GenerateStructure : IServerboundPacket
+{
+    [Field(0)]
+    public VectorF Position { get; set; }
+
+    [Field(1), VarLength]
+    public int Levels { get; set; }
+    
+    [Field(2)]
+    public bool KeepJigsaws { get; set; }
+
+    public int Id => 0x0E;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/LockDifficulty.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/LockDifficulty.cs
@@ -4,18 +4,12 @@ using Obsidian.Serialization.Attributes;
 
 namespace Obsidian.Net.Packets.Play.Serverbound;
 
-public partial class VehicleMove : IServerboundPacket
+public partial class LockDifficulty : IServerboundPacket
 {
-    [Field(0), DataFormat(typeof(double))]
-    public VectorF Position { get; set; }
+    [Field(0)]
+    public bool Locked { get; set; }
 
-    [Field(1)]
-    public float Yaw { get; set; }
-
-    [Field(2)]
-    public float Pitch { get; set; }
-
-    public int Id => 0x15;
+    public int Id => 0x10;
 
     public ValueTask HandleAsync(Server server, Player player)
     {

--- a/Obsidian/Net/Packets/Play/Serverbound/LockDifficulty.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/LockDifficulty.cs
@@ -11,9 +11,5 @@ public partial class LockDifficulty : IServerboundPacket
 
     public int Id => 0x10;
 
-    public ValueTask HandleAsync(Server server, Player player)
-    {
-        server.Logger.LogDebug(this.AsString());
-        return ValueTask.CompletedTask;
-    }
+    public ValueTask HandleAsync(Server server, Player player) => ValueTask.CompletedTask;
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
@@ -22,3 +22,20 @@ public partial class PlayerMovement : IServerboundPacket
         return ValueTask.CompletedTask;
     }
 }
+
+public partial class SetBeaconEffect : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int PrimaryEffect { get; set; }
+    
+    [Field(1), VarLength]
+    public int SecondaryEffect { get; set; }
+
+    public int Id => 0x24;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
@@ -18,24 +18,8 @@ public partial class PlayerMovement : IServerboundPacket
 
     public ValueTask HandleAsync(Server server, Player player)
     {
-        server.Logger.LogDebug(this.AsString());
-        return ValueTask.CompletedTask;
-    }
-}
-
-public partial class SetBeaconEffect : IServerboundPacket
-{
-    [Field(0), VarLength]
-    public int PrimaryEffect { get; set; }
-    
-    [Field(1), VarLength]
-    public int SecondaryEffect { get; set; }
-
-    public int Id => 0x24;
-
-    public ValueTask HandleAsync(Server server, Player player)
-    {
-        server.Logger.LogDebug(this.AsString());
+        //var fallDistance = player.LastPosition.Z - player.Position.Z;
+        //await player.DamageAsync(null, MathF.Max(0, fallDistance - 3f));
         return ValueTask.CompletedTask;
     }
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/PlayerMovement.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class PlayerMovement : IServerboundPacket
+{
+    [Field(0)]
+    public bool OnGround { get; set; }
+
+    public int Id => 0x14;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/PlayerRotation.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/PlayerRotation.cs
@@ -1,4 +1,5 @@
-﻿using Obsidian.Entities;
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
 using Obsidian.Serialization.Attributes;
 
 namespace Obsidian.Net.Packets.Play.Serverbound;
@@ -29,6 +30,7 @@ public partial class PlayerRotation : IServerboundPacket
 
     public async ValueTask HandleAsync(Server server, Player player)
     {
+        if(!OnGround) Globals.PacketLogger.LogDebug(this.AsString());
         await player.UpdateAsync(Yaw, Pitch, OnGround);
     }
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/QueryEntityNbt.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/QueryEntityNbt.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class QueryEntityNbt : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int TransactionId { get; set; }
+    
+    [Field(1), VarLength]
+    public int EntityId { get; set; }
+    
+    public int Id => 0x15;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
@@ -1,0 +1,19 @@
+﻿using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class SelectTrade : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int SelectedSlot { get; set; }
+
+    public int Id => throw new NotImplementedException();
+
+    public ValueTask HandleAsync(Server server, Player player) => throw new NotImplementedException();
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
@@ -13,7 +13,7 @@ public partial class SelectTrade : IServerboundPacket
     [Field(0), VarLength]
     public int SelectedSlot { get; set; }
 
-    public int Id => throw new NotImplementedException();
+    public int Id => 0x23;
 
     public ValueTask HandleAsync(Server server, Player player) => throw new NotImplementedException();
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SelectTrade.cs
@@ -15,5 +15,5 @@ public partial class SelectTrade : IServerboundPacket
 
     public int Id => 0x23;
 
-    public ValueTask HandleAsync(Server server, Player player) => throw new NotImplementedException();
+    public ValueTask HandleAsync(Server server, Player player) => ValueTask.CompletedTask;
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/SetBeaconEffect.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SetBeaconEffect.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class SetBeaconEffect : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int PrimaryEffect { get; set; }
+    
+    [Field(1), VarLength]
+    public int SecondaryEffect { get; set; }
+
+    public int Id => 0x24;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/SetRecipeBookState.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SetRecipeBookState.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class SetRecipeBookState : IServerboundPacket
+{
+    [Field(0), VarLength, ActualType(typeof(int))]
+    public ERecipeBookType BookId { get; private set; }
+
+    [Field(1)]
+    public bool BookOpen { get; private set; }
+    
+    [Field(2)]
+    public bool FilterActive { get; private set; }
+
+    public int Id => 0x1E;
+
+    public SetRecipeBookState()
+    {
+    }
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/Spectate.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/Spectate.cs
@@ -4,18 +4,12 @@ using Obsidian.Serialization.Attributes;
 
 namespace Obsidian.Net.Packets.Play.Serverbound;
 
-public partial class VehicleMove : IServerboundPacket
+public partial class Spectate : IServerboundPacket
 {
-    [Field(0), DataFormat(typeof(double))]
-    public VectorF Position { get; set; }
+    [Field(0)]
+    public Guid TargetPlayer { get; set; }
 
-    [Field(1)]
-    public float Yaw { get; set; }
-
-    [Field(2)]
-    public float Pitch { get; set; }
-
-    public int Id => 0x15;
+    public int Id => 0x2D;
 
     public ValueTask HandleAsync(Server server, Player player)
     {

--- a/Obsidian/Net/Packets/Play/Serverbound/SteerBoat.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/SteerBoat.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class SteerBoat : IServerboundPacket
+{
+    [Field(0)]
+    public bool LeftPaddleTurning { get; set; }
+    [Field(1)]
+    public bool RightPaddleTurning { get; set; }
+
+    public int Id => 0x16;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/TabCompleteRequest.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/TabCompleteRequest.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Net.Packets.Play.Clientbound;
+using Obsidian.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class TabCompleteRequest : IServerboundPacket
+{
+    [Field(0), VarLength]
+    public int TransactionId { get; private set; }
+
+    [Field(1)]
+    public string Text { get; private set; }
+
+    public int Id => 0x06;
+
+    public TabCompleteRequest()
+    {
+    }
+
+    public async ValueTask HandleAsync(Server server, Player player)
+    {
+        var matches = (Text.StartsWith("/") ? server.CommandsHandler.GetAllCommands().Select(x=> new MatchItem(x.Name, false)): server.Players.Select(x => new MatchItem(x.Username, false))).ToList();
+        await player.client.QueuePacketAsync(new TabCompleteResponse(TransactionId, 0, Text.Length, matches.Count, matches));
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/UpdateJigsawBlock.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/UpdateJigsawBlock.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class UpdateJigsawBlock : IServerboundPacket
+{
+    [Field(0)]
+    public VectorF Location { get; set; }
+    
+    [Field(1)]
+    public string Name { get; set; }
+    
+    [Field(2)]
+    public string Target { get; set; }
+    
+    [Field(3)]
+    public string Pool { get; set; }
+
+    [Field(4)]
+    public string FinalState { get; set; }
+
+    [Field(5)]
+    public string JointType { get; set; }
+
+    public int Id => 0x29;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/UpdateSign.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/UpdateSign.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class UpdateSign : IServerboundPacket
+{
+    [Field(0)]
+    public VectorF Location { get; set; }
+
+    [Field(1), FixedLength(384)]
+    public string Line1 { get; set; }
+    
+    [Field(2), FixedLength(384)]
+    public string Line2 { get; set; }
+    
+    [Field(3), FixedLength(384)]
+    public string Line3 { get; set; }
+    
+    [Field(4), FixedLength(384)]
+    public string Line4 { get; set; }
+
+    public int Id => 0x2B;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Net/Packets/Play/Serverbound/VehicleMove.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/VehicleMove.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Entities;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Serverbound;
+
+public partial class VehicleMove : IServerboundPacket
+{
+    [Field(0), DataFormat(typeof(double))]
+    public VectorF Position { get; set; }
+    
+    [Field(1)]
+    public float Yaw { get; set; }
+    
+    [Field(2)]
+    public float Pitch { get; set; }
+
+    public int Id => 0x15;
+
+    public ValueTask HandleAsync(Server server, Player player)
+    {
+        server.Logger.LogDebug(this.AsString());
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -52,6 +52,7 @@
 		<None Remove="Assets\default_dimensions.xaml" />
 		<None Remove="Assets\entity_types.json" />
 		<None Remove="Assets\fluids.json" />
+		<None Remove="Assets\packet_debug.json" />
 		<None Remove="Assets\tags.json" />
 		<None Remove="Serializer\Attributes\NewFile1.txt" />
 		<None Remove="Serializer\Enums\NewFile1.txt" />
@@ -103,6 +104,9 @@
 		</EmbeddedResource>
 		<EmbeddedResource Update="Assets\items.json">
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Assets\packet_debug.json">
+		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</EmbeddedResource>
 		<EmbeddedResource Update="Assets\tags.json">
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -115,6 +115,8 @@ public partial class Server : IServer
 
         Directory.CreateDirectory(PermissionPath);
 
+        Globals.PacketDebugHandler = new();
+
         if (Config.UDPBroadcast)
         {
             _ = Task.Run(async () =>

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -35,7 +35,7 @@ public class ClientHandler
         //Packets.TryAdd(0x0C, EditBook);
         //Packets.TryAdd(0x0E, InteractEntity);
         //Packets.TryAdd(0x0F, GenerateStructure);
-        //Packets.TryAdd(0x11, LockDifficulty);
+        //Packets.TryAdd(0x10, LockDifficulty);
         Packets.TryAdd(0x11, new PlayerPosition());
         Packets.TryAdd(0x12, new PlayerPositionAndRotation());
         Packets.TryAdd(0x13, new PlayerRotation());
@@ -70,6 +70,7 @@ public class ClientHandler
 
     public async Task HandlePlayPackets(int id, byte[] data, Client client)
     {
+        bool missing = false;
         switch (id)
         {
             case 0x00:
@@ -109,6 +110,10 @@ public class ClientHandler
                 await HandleFromPoolAsync<InteractEntity>(data, client);
                 break;
 
+            //case 0x14:
+            //    await HandleFromPoolAsync<PlayerMovement> (data, client);
+            //    break;
+                
             case 0x17:
                 await HandleFromPoolAsync<PickItem>(data, client);
                 break;
@@ -151,7 +156,10 @@ public class ClientHandler
 
             default:
                 if (!Packets.TryGetValue(id, out var packet))
-                    return;
+                {
+                    missing = true;
+                    break;
+                }
 
                 try
                 {
@@ -164,6 +172,14 @@ public class ClientHandler
                         Globals.PacketLogger.LogError(e.Message + Environment.NewLine + e.StackTrace);
                 }
                 break;
+        }
+        if (!missing)
+        {
+            //Globals.PacketLogger.LogDebug($"{id.ToPacketName()})");
+        }
+        else
+        {
+            Globals.PacketLogger.LogWarning($"{id.ToPacketName()}");
         }
     }
 

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -49,7 +49,7 @@ public class ClientHandler
         //Packets.TryAdd(0x1C, new EntityAction()); !
         //Packets.TryAdd(0x1D, SteerVehicle);
         //Packets.TryAdd(0x1E, new SetDisplayedRecipe()); !
-        //Packets.TryAdd(0x1F, SetRecipeBookState);
+        //Packets.TryAdd(0x1F, new SetRecipeBookState()); !
         //Packets.TryAdd(0x20, new NameItem()); !
         //Packets.TryAdd(0x21, ResourcePackStatus);
         //Packets.TryAdd(0x22, AdvancementTab);
@@ -123,6 +123,10 @@ public class ClientHandler
 
             case 0x1B:
                 await HandleFromPoolAsync<EntityAction>(data, client);
+                break;
+
+            case 0x1E:
+                await HandleFromPoolAsync<SetRecipeBookState>(data, client);
                 break;
 
             case 0x1F:

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -35,6 +35,10 @@ public class ClientHandler
                 await HandleFromPoolAsync<TeleportConfirm>(data, client);
                 break;
 
+            //case 0x02: // Only used on internal server
+            //    await HandleFromPoolAsync<SetDifficulty>(data, client);
+            //    break;
+
             case 0x03:
                 await HandleFromPoolAsync<IncomingChatMessage>(data, client);
                 break;
@@ -197,7 +201,7 @@ public class ClientHandler
         }
         else
         {
-            Globals.PacketLogger.LogWarning($"{id.ToPacketName()}");
+            //Globals.PacketLogger.LogWarning($"{id.ToPacketName()}");
         }
     }
 

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -19,52 +19,10 @@ public class ClientHandler
 
     public void RegisterHandlers()
     {
-        // ! == moved to HandlePlayPackets
-        //Packets.TryAdd(0x00, new TeleportConfirm()); !
-        //Packets.TryAdd(0x01, QueryBlockNBT);
-        //Packets.TryAdd(0x02, SetDifficulty);
-        //Packets.TryAdd(0x03, new IncomingChatMessage()); !
-        //Packets.TryAdd(0x04, ClientStatus);
-        //Packets.TryAdd(0x05, new ClientSettings()); !
-        //Packets.TryAdd(0x06, new TabComplete());
-        //Packets.TryAdd(0x07, new WindowConfirmation()); !
-        //Packets.TryAdd(0x08, new ClickWindowButton()); !
-        //Packets.TryAdd(0x09, new ClickWindow()); !
-        //Packets.TryAdd(0x0A, new CloseWindow()); !
-        //Packets.TryAdd(0x0B, new PluginMessage()); !
-        //Packets.TryAdd(0x0C, EditBook);
-        //Packets.TryAdd(0x0E, InteractEntity);
-        //Packets.TryAdd(0x0F, GenerateStructure);
-        //Packets.TryAdd(0x10, LockDifficulty);
         Packets.TryAdd(0x11, new PlayerPosition());
         Packets.TryAdd(0x12, new PlayerPositionAndRotation());
         Packets.TryAdd(0x13, new PlayerRotation());
-        //Packets.TryAdd(0x15, PlayerMovement);
-        //Packets.TryAdd(0x16, VehicleMove);
-        //Packets.TryAdd(0x17, SteerBoat);
-        //Packets.TryAdd(0x18, new PickItem()); !
-        //Packets.TryAdd(0x19, new CraftRecipeRequest()); !
-        //Packets.TryAdd(0x1A, PlayerAbilities);
-        //Packets.TryAdd(0x1B, new PlayerDigging()); !
-        //Packets.TryAdd(0x1C, new EntityAction()); !
-        //Packets.TryAdd(0x1D, SteerVehicle);
-        //Packets.TryAdd(0x1E, new SetDisplayedRecipe()); !
-        //Packets.TryAdd(0x1F, new SetRecipeBookState()); !
-        //Packets.TryAdd(0x20, new NameItem()); !
-        //Packets.TryAdd(0x21, ResourcePackStatus);
-        //Packets.TryAdd(0x22, AdvancementTab);
-        //Packets.TryAdd(0x23, SelectTrade);
-        //Packets.TryAdd(0x24, SetBeaconEffect);
         Packets.TryAdd(0x25, new ServerHeldItemChange());
-        //Packets.TryAdd(0x26, UpdateCommandBlock);
-        //Packets.TryAdd(0x27, UpdateCommandBlockMinecart);
-        //Packets.TryAdd(0x28, new CreativeInventoryAction()); !
-        //Packets.TryAdd(0x29, UpdateJigsawBlock);
-        //Packets.TryAdd(0x2A, UpdateStructureBlock);
-        //Packets.TryAdd(0x2B, UpdateSign);
-        //Packets.TryAdd(0x2C, new Animation());
-        //Packets.TryAdd(0x2D, Spectate);
-        //Packets.TryAdd(0x2E, new PlayerBlockPlacement()); !
         Packets.TryAdd(0x2F, new UseItem());
     }
 

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -64,18 +64,44 @@ public class ClientHandler
             case 0x0A:
                 await HandleFromPoolAsync<ServerboundPluginMessage>(data, client);
                 break;
-            case 0x0F:
-                await HandleFromPoolAsync<KeepAlivePacket>(data, client);
-                break;
 
+            case 0x0B:
+                await HandleFromPoolAsync<EditBook>(data, client); // TODO: Not finished
+                break;
+                
+            case 0x0C:
+                await HandleFromPoolAsync<QueryEntityNbt>(data, client); // TODO: Not finished
+                break;
+                
             case 0x0D:
                 await HandleFromPoolAsync<InteractEntity>(data, client);
                 break;
 
-            //case 0x14:
-            //    await HandleFromPoolAsync<PlayerMovement> (data, client);
-            //    break;
+            case 0x0E:
+                await HandleFromPoolAsync<GenerateStructure>(data, client); // TODO: Not finished
+                break;
                 
+            case 0x0F:
+                await HandleFromPoolAsync<KeepAlivePacket>(data, client);
+                break;
+
+            //case 0x11:
+            //case 0x12:
+            //case 0x13:
+            //  break;
+
+            case 0x14:
+                await HandleFromPoolAsync<PlayerMovement>(data, client); // TODO: Not finished
+                break;
+
+            case 0x15:
+                await HandleFromPoolAsync<VehicleMove>(data, client);
+                break;
+                
+            case 0x16:
+                await HandleFromPoolAsync<SteerBoat>(data, client); // TODO: Not finished
+                break;
+
             case 0x17:
                 await HandleFromPoolAsync<PickItem>(data, client);
                 break;
@@ -104,10 +130,14 @@ public class ClientHandler
                 await HandleFromPoolAsync<NameItem>(data, client);
                 break;
 
+            case 0x23:
+                await HandleFromPoolAsync<SelectTrade>(data, client);
+                break;
+
             case 0x28:
                 await HandleFromPoolAsync<CreativeInventoryAction>(data, client);
                 break;
-
+                
             case 0x2C:
                 await HandleFromPoolAsync<AnimationPacket>(data, client);
                 break;

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -26,7 +26,7 @@ public class ClientHandler
         //Packets.TryAdd(0x03, new IncomingChatMessage()); !
         //Packets.TryAdd(0x04, ClientStatus);
         //Packets.TryAdd(0x05, new ClientSettings()); !
-        //Packets.TryAdd(0x06, TabComplete);
+        //Packets.TryAdd(0x06, new TabComplete());
         //Packets.TryAdd(0x07, new WindowConfirmation()); !
         //Packets.TryAdd(0x08, new ClickWindowButton()); !
         //Packets.TryAdd(0x09, new ClickWindow()); !
@@ -85,6 +85,10 @@ public class ClientHandler
                 break;
             case 0x05:
                 await HandleFromPoolAsync<ClientSettings>(data, client);
+                break;
+                
+            case 0x06:
+                await HandleFromPoolAsync<TabCompleteRequest>(data, client);
                 break;
 
             case 0x07:

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -84,6 +84,10 @@ public class ClientHandler
             case 0x0F:
                 await HandleFromPoolAsync<KeepAlivePacket>(data, client);
                 break;
+                
+            case 0x10:
+                await HandleFromPoolAsync<LockDifficulty> (data, client);
+                break;
 
             //case 0x11:
             //case 0x12:
@@ -138,13 +142,32 @@ public class ClientHandler
                 await HandleFromPoolAsync<CreativeInventoryAction>(data, client);
                 break;
                 
+            case 0x29:
+                await HandleFromPoolAsync<UpdateJigsawBlock>(data, client); // TODO: Not finished
+                break;
+                
+            case 0x2A:
+                await HandleFromPoolAsync<AnimationPacket>(data, client);
+                break;
+                
+            case 0x2B:
+                await HandleFromPoolAsync<UpdateSign> (data, client);
+                break;
+                
             case 0x2C:
                 await HandleFromPoolAsync<AnimationPacket>(data, client);
+                break;
+                
+            case 0x2D:
+                await HandleFromPoolAsync<Spectate>(data, client); // TODO: Not finished
                 break;
 
             case 0x2E:
                 await HandleFromPoolAsync<PlayerBlockPlacement>(data, client);
                 break;
+
+            //case 0x2F:
+            //    break;
 
             default:
                 if (!Packets.TryGetValue(id, out var packet))

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -92,7 +92,7 @@ public class ClientHandler
             //case 0x11:
             //case 0x12:
             //case 0x13:
-            //  break;
+            //    break;
 
             case 0x14:
                 await HandleFromPoolAsync<PlayerMovement>(data, client); // TODO: Not finished
@@ -137,6 +137,13 @@ public class ClientHandler
             case 0x23:
                 await HandleFromPoolAsync<SelectTrade>(data, client);
                 break;
+                
+            case 0x24:
+                await HandleFromPoolAsync<SetBeaconEffect>(data, client); // TODO: Not finished
+                break;
+
+            //case 0x25:
+            //    break;
 
             case 0x28:
                 await HandleFromPoolAsync<CreativeInventoryAction>(data, client);

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -86,7 +86,7 @@ public class ClientHandler
                 break;
                 
             case 0x10:
-                await HandleFromPoolAsync<LockDifficulty> (data, client);
+                await HandleFromPoolAsync<LockDifficulty> (data, client); // TODO: Not finished
                 break;
 
             //case 0x11:
@@ -153,12 +153,8 @@ public class ClientHandler
                 await HandleFromPoolAsync<UpdateJigsawBlock>(data, client); // TODO: Not finished
                 break;
                 
-            case 0x2A:
-                await HandleFromPoolAsync<AnimationPacket>(data, client);
-                break;
-                
             case 0x2B:
-                await HandleFromPoolAsync<UpdateSign> (data, client);
+                await HandleFromPoolAsync<UpdateSign>(data, client); // TODO: Not finished
                 break;
                 
             case 0x2C:

--- a/Obsidian/Utilities/PacketDebugHandler.cs
+++ b/Obsidian/Utilities/PacketDebugHandler.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.Logging;
+using Obsidian.Net.Packets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Obsidian.Utilities;
+
+internal class PacketDebugHandler
+{
+    private static readonly string mainDomain = "Obsidian.Assets";
+
+    private static readonly JsonSerializerOptions packetJsonOptions = new()
+    {
+
+    };
+    private List<PacketDebugItem> Packets = new();
+
+    public PacketDebugHandler()
+    {
+        RegisterAsync();
+    }
+
+    public async void RegisterAsync()
+    {
+        using Stream fs = Assembly.GetExecutingAssembly().GetManifestResourceStream($"{mainDomain}.packet_debug.json");
+
+        var list = await fs.FromJsonAsync<List<PacketDebugItem>>(packetJsonOptions);
+
+        Packets = list;
+
+        Globals.PacketLogger.LogDebug($"Successfully add {Packets.Count} packets to debug database...");
+    }
+    internal string GetPacket(ClientState state, PacketType type, int id)
+    {
+        try
+        {
+            var packet=Packets.First(x => x.State == state && x.Id == $"0x{id:X2}" && x.BoundTo == type);
+            return packet.AsString();
+        }
+        catch (Exception ex)
+        {
+        }
+
+        return new PacketDebugItem { Id = $"0x{id:X2}", BoundTo = type, State = state }.AsString();
+    }
+}
+
+public class PacketDebugItem
+{
+    [JsonPropertyName("state"), JsonConverter(typeof(JsonStringEnumConverter))]
+    public ClientState? State { get; set; }
+
+    [JsonPropertyName("bound_to"), JsonConverter(typeof(JsonStringEnumConverter))]
+    public PacketType BoundTo { get; set; }
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+}
+
+public enum PacketType
+{
+    Client,
+    Server
+}


### PR DESCRIPTION
# Add some client and serverbound packets

## Login
### Clientbound
- [x] LoginPluginRequest (0x04)

### Serverbound
- [x] LoginPluginResponse (0x02)

## Play
### Clientbound
- [x] TradeList (0x06)
- [x] TabComplete (0x11)

### Serverbound
- [x] SetDifficulty (0x02) // It does nothing (in servers), but added packet anyway
- [x] TabComplete (0x06)
- [ ] EditBook (0x0B)
- [ ] QueryEntityNbt (0x0C)
- [ ] GenerateStructure (0x0E)
- [ ] LockDifficulty (0x10)
- [ ] PlayerMovement (0x14)
- [x] VehicleMove (0x15)
- [ ] SteerBoat (0x16)
- [x] SetRecipeBookState (0x1E)
- [ ] ResourcePackStatus (0x21)
- [x] SelectTrade (0x23)
- [ ] SetBeaconEffect (0x24)
- [ ] UpdateJigsawBlock (0x29)
- [ ] UpdateSign (0x2B)
- [x] Spectate (0x2D)

A part of #85.