### PR TITLE
Change player names to be case-insensitive

### DIFF
--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -155,13 +155,13 @@ public partial class Server : IServer
     /// </summary>
     /// <param name="username">The username you want to check for.</param>
     /// <returns>True if the player is online.</returns>
-    public bool IsPlayerOnline(string username) => OnlinePlayers.Any(x => x.Value.Username == username);
+    public bool IsPlayerOnline(string username) => OnlinePlayers.Any(x => x.Value.Username.EqualsIgnoreCase(username));
 
     public bool IsPlayerOnline(Guid uuid) => OnlinePlayers.ContainsKey(uuid);
 
-    public IPlayer GetPlayer(string username) => OnlinePlayers.FirstOrDefault(player => player.Value.Username == username).Value;
+    public IPlayer GetPlayer(string username) => OnlinePlayers.FirstOrDefault(player => player.Value.Username.EqualsIgnoreCase(username)).Value;
 
-    public IPlayer GetPlayer(Guid uuid) => OnlinePlayers.TryGetValue(uuid, out var player) ? player : null;
+    public IPlayer? GetPlayer(Guid uuid) => OnlinePlayers.TryGetValue(uuid, out var player) ? player : null;
 
     public IPlayer GetPlayer(int entityId) => OnlinePlayers.FirstOrDefault(player => player.Value.EntityId == entityId).Value;
 


### PR DESCRIPTION
Since minecraft names are case-insensitive, it makes sense to do their comparisons as such.

Another possible design would be something like:
```cs
public bool IsPlayerOnline(string username, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase);
```
or
```cs
public bool IsPlayerOnline(string username, bool caseSensitive = false);
```