### PR TITLE
Fix subgroup commands

### DIFF
--- a/Obsidian/Commands/Framework/CommandHandler.cs
+++ b/Obsidian/Commands/Framework/CommandHandler.cs
@@ -89,7 +89,7 @@ public class CommandHandler
     public void RegisterCommandClass(PluginContainer plugin, Type type, object instance = null)
     {
         RegisterSubgroups(type, plugin);
-        RegisterSubcommands(type, plugin, instance);
+        RegisterSubcommands(type, plugin);
     }
 
     public object CreateCommandRootInstance(Type type, PluginContainer plugin)
@@ -131,7 +131,7 @@ public class CommandHandler
             var info = st.GetCustomAttribute<CommandInfoAttribute>();
             var issuers = st.GetCustomAttribute<IssuerScopeAttribute>()?.Issuers ?? DefaultIssuerScope;
 
-            var cmd = new Command(name, aliases.ToArray(), info?.Description ?? string.Empty, info?.Usage ?? string.Empty, parent, checks.ToArray(), this, plugin, null, type, issuers);
+            var cmd = new Command(name, aliases.ToArray(), info?.Description ?? string.Empty, info?.Usage ?? string.Empty, parent, checks.ToArray(), this, plugin, null, st, issuers);
 
             RegisterSubgroups(st, plugin, cmd);
             RegisterSubcommands(st, plugin, cmd);
@@ -140,7 +140,7 @@ public class CommandHandler
         }
     }
 
-    private void RegisterSubcommands(Type type, PluginContainer plugin, object instance, Command parent = null)
+    private void RegisterSubcommands(Type type, PluginContainer plugin, Command? parent = null)
     {
         // loop through methods and find valid commands
         var methods = type.GetMethods();


### PR DESCRIPTION
```diff
- private void RegisterSubcommands(Type type, PluginContainer plugin, object instance, Command parent = null)
```
`instance` was unused, but the method was being called as:
```cs
RegisterSubcommands(st, plugin, cmd);
```
`cmd` was supposed to be `parent`, but it was used as `instance` instead, causing `parent` to be `null`, causing a command to have no overloads registered. This has lead to the command always causing an argument mismatch error.

Furthermore, command groups had their correct parent type, but subgroups didn't, causing `TargetMethodException` when trying to invoke the command method on a wrong type.