### PR TITLE
Fix block/biome container indexing

### DIFF
--- a/Obsidian/ChunkData/BiomeContainer.cs
+++ b/Obsidian/ChunkData/BiomeContainer.cs
@@ -70,4 +70,6 @@ public sealed class BiomeContainer : DataContainer<Biomes>
     {
         return new BiomeContainer(Palette.Clone(), DataArray.Clone());
     }
+
+    public override int GetIndex(int x, int y, int z) => (y << 2 | z) << 2 | x;
 }

--- a/Obsidian/ChunkData/BiomeContainer.cs
+++ b/Obsidian/ChunkData/BiomeContainer.cs
@@ -9,13 +9,13 @@ public sealed class BiomeContainer : DataContainer<Biomes>
 
     public override DataArray DataArray { get; protected set; }
 
-    internal BiomeContainer(byte bitsPerEntry = 2) : base(bitsPerEntry)
+    internal BiomeContainer(byte bitsPerEntry = 2)
     {
         this.Palette = bitsPerEntry.DetermineBiomePalette();
-        this.DataArray = new(this.BitsPerEntry, 64);
+        this.DataArray = new(bitsPerEntry, 64);
     }
 
-    private BiomeContainer(IPalette<Biomes> palette, DataArray dataArray, byte bitsPerEntry) : base(bitsPerEntry)
+    private BiomeContainer(IPalette<Biomes> palette, DataArray dataArray)
     {
         Palette = palette;
         DataArray = dataArray;
@@ -68,6 +68,6 @@ public sealed class BiomeContainer : DataContainer<Biomes>
 
     public BiomeContainer Clone()
     {
-        return new BiomeContainer(Palette.Clone(), DataArray.Clone(), BitsPerEntry);
+        return new BiomeContainer(Palette.Clone(), DataArray.Clone());
     }
 }

--- a/Obsidian/ChunkData/BlockStateContainer.cs
+++ b/Obsidian/ChunkData/BlockStateContainer.cs
@@ -15,7 +15,7 @@ public sealed class BlockStateContainer : DataContainer<Block>
     private readonly DirtyCache<short> validBlockCount;
 #endif
 
-    internal BlockStateContainer(byte bitsPerEntry = 4) : base(bitsPerEntry)
+    internal BlockStateContainer(byte bitsPerEntry = 4)
     {
         DataArray = new DataArray(bitsPerEntry, 4096);
         Palette = bitsPerEntry.DetermineBlockPalette();
@@ -25,7 +25,7 @@ public sealed class BlockStateContainer : DataContainer<Block>
 #endif
     }
 
-    private BlockStateContainer(IPalette<Block> palette, DataArray dataArray, byte bitsPerEntry) : base(bitsPerEntry)
+    private BlockStateContainer(IPalette<Block> palette, DataArray dataArray)
     {
         Palette = palette;
         DataArray = dataArray;
@@ -171,6 +171,8 @@ public sealed class BlockStateContainer : DataContainer<Block>
 
     public BlockStateContainer Clone()
     {
-        return new BlockStateContainer(Palette.Clone(), DataArray.Clone(), BitsPerEntry);
+        return new BlockStateContainer(Palette.Clone(), DataArray.Clone());
     }
+
+    public override int GetIndex(int x, int y, int z) => (y << 4 | z) << 4 | x;
 }

--- a/Obsidian/ChunkData/DataContainer.cs
+++ b/Obsidian/ChunkData/DataContainer.cs
@@ -4,13 +4,11 @@ using Obsidian.Utilities.Collection;
 namespace Obsidian.ChunkData;
 public abstract class DataContainer<T>
 {
-    public byte BitsPerEntry { get; }
+    public byte BitsPerEntry => (byte)DataArray.BitsPerEntry;
 
     public abstract IPalette<T> Palette { get; internal set; }
 
     public abstract DataArray DataArray { get; protected set; }
-
-    public DataContainer(byte bitsPerEntry) => this.BitsPerEntry = bitsPerEntry;
 
     public virtual int GetIndex(int x, int y, int z) => (y << this.BitsPerEntry | z) << this.BitsPerEntry | x;
 


### PR DESCRIPTION
It all comes down to this line
```diff
+ public override int GetIndex(int x, int y, int z) => (y << 4 | z) << 4 | x;
```
and this line
```diff
+ public override int GetIndex(int x, int y, int z) => (y << 2 | z) << 2 | x;
```

`DataArray` indexing is not dependent on `BitsPerEntry,` but rather on storage size, which is fixed for `Block/BiomeContainer`.

These numbers (2/4) mean how many of `X` (blocks/biomes) there are on one axis. So there are 2^**4** blocks on x/y/z axis and 2^**2** biomes on x/y/z axis.