### PR TITLE
Fix infinite loop in VarInt length calculation for negative numbers

### DIFF
--- a/Obsidian/Utilities/Extensions.Numerics.cs
+++ b/Obsidian/Utilities/Extensions.Numerics.cs
@@ -25,8 +25,9 @@ public static partial class Extensions
         return (float)random.NextDouble();
     }
 
-    public static int GetVarIntLength(this int val)
+    public static int GetVarIntLength(this int value)
     {
+        uint val = (uint)value;
         int amount = 0;
         do
         {


### PR DESCRIPTION
The only change in code-gen (x64) is `sar` → `shr` (so no regression).