### PR TITLE
Switching game modes now requires OP. Provide user feedback on command failure.

### DIFF
--- a/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
+++ b/Obsidian.API/_Attributes/RequirePermissionAttribute.cs
@@ -3,15 +3,18 @@
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
 public sealed class RequirePermissionAttribute : BaseExecutionCheckAttribute
 {
-    private string[] permissions;
-    private PermissionCheckType checkType;
-    private bool op;
+    private readonly string[] _permissions;
+    private readonly PermissionCheckType _checkType;
+    private readonly bool _op;
+
+    public PermissionCheckType CheckType => _checkType;
+    public string[] RequiredPermissions => _permissions;
 
     public RequirePermissionAttribute(PermissionCheckType checkType = PermissionCheckType.All, bool op = true, params string[] permissions)
     {
-        this.permissions = permissions;
-        this.checkType = checkType;
-        this.op = op;
+        _permissions = permissions;
+        _checkType = checkType;
+        _op = op;
     }
 
     public override Task<bool> RunChecksAsync(CommandContext context)
@@ -20,11 +23,11 @@ public sealed class RequirePermissionAttribute : BaseExecutionCheckAttribute
             return Task.FromResult(true);
         if (context.Player == null)
             return Task.FromResult(false);
-        if (this.op && context.Player.IsOperator)
+        if (_op && context.Player.IsOperator)
             return Task.FromResult(true);
 
-        if (this.permissions.Length > 0)
-            return Task.FromResult(checkType == PermissionCheckType.All ? context.Player.HasAllPermissions(permissions) : context.Player.HasAnyPermission(permissions));
+        if (_permissions.Length > 0)
+            return Task.FromResult(_checkType == PermissionCheckType.All ? context.Player.HasAllPermissions(_permissions) : context.Player.HasAnyPermission(_permissions));
 
         return Task.FromResult(false);
     }

--- a/Obsidian/Commands/Framework/CommandHandler.cs
+++ b/Obsidian/Commands/Framework/CommandHandler.cs
@@ -182,13 +182,33 @@ public class CommandHandler
             // if string is "command-qualified" we'll try to execute it.
             string[] command = CommandParser.SplitQualifiedString(qualified); // first, parse the command
 
-            await ExecuteCommand(command, ctx);
+            try
+            {
+                await ExecuteCommand(command, ctx);
+            }
+            catch (CommandExecutionCheckException ex)
+            {
+                await ProvideFeedbackToSender(ctx, ex);
+            }
         }
     }
 
+    private static async Task ProvideFeedbackToSender(CommandContext ctx, CommandExecutionCheckException ex)
+    {
+        switch (ex)
+        {
+            case NoPermissionException:
+                await ctx.Sender.SendMessageAsync(ChatMessage.Simple("You are not allowed to execute this command", ChatColor.Red));
+                break;
+            default:
+                await ctx.Sender.SendMessageAsync(ChatMessage.Simple(ex.Message, ChatColor.Red));
+                break;
+        }
+    } 
+
     private async Task ExecuteCommand(string[] command, CommandContext ctx)
     {
-        Command cmd = null;
+        Command? cmd = default;
         var args = command;
 
         // Search for correct Command class in this._commands.
@@ -201,7 +221,6 @@ public class CommandHandler
         if (cmd is not null)
         {
             ctx.Plugin = cmd.Plugin?.Plugin;
-
             await cmd.ExecuteAsync(ctx, args);
         }
         else

--- a/Obsidian/Commands/Framework/Entities/Command.cs
+++ b/Obsidian/Commands/Framework/Entities/Command.cs
@@ -1,6 +1,7 @@
 ﻿using Obsidian.Commands.Framework.Exceptions;
 using Obsidian.Plugins;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Obsidian.Commands.Framework.Entities;
 
@@ -157,7 +158,11 @@ public class Command
             {
                 // A check failed.
                 // TODO: Tell user what arg failed?
-                throw new CommandExecutionCheckException($"One or more execution checks failed.");
+                throw c switch
+                {
+                    RequirePermissionAttribute r => new NoPermissionException(r.RequiredPermissions, r.CheckType),
+                    _ => new CommandExecutionCheckException($"One or more execution checks failed."),
+                };
             }
         }
 

--- a/Obsidian/Commands/Framework/Exceptions/NoPermissionException.cs
+++ b/Obsidian/Commands/Framework/Exceptions/NoPermissionException.cs
@@ -1,0 +1,19 @@
+﻿namespace Obsidian.Commands.Framework.Exceptions;
+
+/// <summary>
+/// Exception indicating that a command can not be executed by a certain CommandExecutor due to missing required permissions.
+/// </summary>
+internal class NoPermissionException : CommandExecutionCheckException
+{
+    public PermissionCheckType CheckType { get; }
+    public string[] RequiredPermissions { get; }
+
+
+    public NoPermissionException(string[] requiredPermsissions, PermissionCheckType checkType) : base("CommandSender does not have the required permissions.")
+    {
+        RequiredPermissions = requiredPermsissions;
+        CheckType = checkType;
+    }
+
+}
+

--- a/Obsidian/Commands/MainCommandModule.cs
+++ b/Obsidian/Commands/MainCommandModule.cs
@@ -197,6 +197,7 @@ public class MainCommandModule
     [Command("gamemode")]
     [CommandInfo("Change your gamemode.", "/gamemode <survival/creative/adventure/spectator>")]
     [IssuerScope(CommandIssuers.Client)]
+    [RequirePermission(op: true, permissions: "obsidian.gamemode")]
     public async Task GamemodeAsync(CommandContext ctx, string gamemode)
     {
         var player = ctx.Player;


### PR DESCRIPTION
Addresses point 2 in https://github.com/ObsidianMC/Obsidian/issues/270.

While trying to fix this, I encountered a todo and gave it a shot:
`                // A check failed.
                // TODO: Tell user what arg failed?`

Instead of printing the `CommandExecutionCheckException` to console, exceptions inheriting `CommandExecutionCheckException` will now get caught and can provide feedback to the command executor if applicable. 

