### PR TITLE
Update Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
+.git
 .github
 .gitignore
+.editorconfig
+docker-compose.yml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore
@@ -6,7 +6,7 @@ RUN dotnet publish Obsidian.ConsoleApp/ -c Release -r linux-musl-x64 --self-cont
 
 FROM alpine:latest
 WORKDIR /app
-COPY --from=build /src/Obsidian.ConsoleApp/bin/Release/net6.0/linux-musl-x64/publish/ .
+COPY --from=build /src/Obsidian.ConsoleApp/bin/Release/net7.0/linux-musl-x64/publish/ .
 RUN apk upgrade --update-cache --available && apk add openssl libstdc++ && rm -rf /var/cache/apk/*
 
 WORKDIR /files

--- a/Obsidian/Utilities/Config.cs
+++ b/Obsidian/Utilities/Config.cs
@@ -6,7 +6,7 @@ namespace Obsidian.Utilities;
 
 public class ServerConfiguration : IServerConfiguration
 {
-    public string Motd { get; set; } = "§k||||§r §5Obsidian §cPre§r-§cRelease §r§k||||§r \n§r§lRunning on .NET §l§c6 §r§l<3";
+    public string Motd { get; set; } = "§k||||§r §5Obsidian §cPre§r-§cRelease §r§k||||§r \n§r§lRunning on .NET §l§c7 §r§l<3";
 
     public int Port { get; set; } = 25565;
 


### PR DESCRIPTION
- Fix build errors by updating Docker image to use .NET 7
- Update MOTD to say .NET 7 instead of .NET 6