### PR TITLE
Bugfix/global logger removal

### DIFF
--- a/Obsidian.ConsoleApp/Logging/Logger.cs
+++ b/Obsidian.ConsoleApp/Logging/Logger.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Obsidian.API;
 using Obsidian.Utilities;
+using System.Diagnostics;
 
 namespace Obsidian.ConsoleApp.Logging;
 
@@ -62,6 +63,12 @@ public class Logger : ILogger<Server>
 
         var message = formatter(state, exception);
         var lines = message.Split('\n');
+
+        if (message.IsNullOrEmpty())
+        { 
+            this.LogTrace($"Empty log message sent. Dumping stacktrace:\n{new System.Diagnostics.StackTrace().ToString().Replace("\n", "            ")}");
+            return;
+        }
 
         lock (_lock)
             for (var i = 0; i < lines.Length; i++)

--- a/Obsidian/Globals.cs
+++ b/Obsidian/Globals.cs
@@ -11,7 +11,6 @@ public static class Globals
 {
     public static HttpClient HttpClient { get; } = new();
     public static XorshiftRandom Random { get; } = new();
-    public static ILogger PacketLogger { get; set; }
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/Obsidian/Net/MinecraftStream.cs
+++ b/Obsidian/Net/MinecraftStream.cs
@@ -50,6 +50,7 @@ public partial class MinecraftStream : Stream
         this.BaseStream = new MemoryStream(data);
     }
 
+    // Unused
     public async Task DumpAsync(bool clear = true, IPacket packet = null)
     {
         if (this.debugMemoryStream == null)
@@ -64,9 +65,10 @@ public partial class MinecraftStream : Stream
         if (clear)
             await ClearDebug();
 
-        Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
+        //Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
     }
 
+    // unused
     public async Task DumpAsync(bool clear = true, string name = "")
     {
         if (this.debugMemoryStream == null)
@@ -81,7 +83,7 @@ public partial class MinecraftStream : Stream
         if (clear)
             await ClearDebug();
 
-        Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
+        //Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
     }
 
     public Task ClearDebug()

--- a/Obsidian/Net/Packets/Play/KeepAlivePacket.cs
+++ b/Obsidian/Net/Packets/Play/KeepAlivePacket.cs
@@ -22,8 +22,8 @@ public partial class KeepAlivePacket : IClientboundPacket, IServerboundPacket
 
     public ValueTask HandleAsync(Server server, Player player)
     {
-        Globals.PacketLogger.LogDebug($"Keep alive {player.Username} [{KeepAliveId}] Missed: {player.client.missedKeepalives - 1}"); // Missed is 1 more bc we just handled one
-
+        server.Logger.LogDebug($"Keep alive {player.Username} [{KeepAliveId}] Missed: {player.client.missedKeepalives - 1}"); // Missed is 1 more bc we just handled one
+        
         player.client.missedKeepalives = 0;
 
         return ValueTask.CompletedTask;

--- a/Obsidian/Server.Events.cs
+++ b/Obsidian/Server.Events.cs
@@ -236,11 +236,11 @@ public partial class Server
 
         joined.World.TryAddPlayer(joined);
 
-        BroadcastMessage(ChatMessage.Simple(string.Empty).AddExtra(new ChatMessage
+        BroadcastMessage(new ChatMessage
         {
             Text = string.Format(Config.JoinMessage, e.Player.Username),
             Color = HexColor.Yellow
-        }));
+        });
 
         foreach (Player other in Players)
         {

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -192,7 +192,7 @@ public partial class Server : IServer
     public void BroadcastMessage(PlayerChatMessagePacket message)
     {
         _chatMessagesQueue.Enqueue(message);
-        _logger.LogInformation(message.SignedMessage.Text);
+        _logger.LogInformation($"<{message.SenderDisplayName.Text}> {message.SignedMessage.Text}");
     }
 
     /// <summary>

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -163,7 +163,7 @@ public class ClientHandler
                 catch (Exception e)
                 {
                     if (this.config.VerboseExceptionLogging)
-                        Globals.PacketLogger.LogError(e.Message + Environment.NewLine + e.StackTrace);
+                        client.Logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
                 }
                 break;
         }
@@ -180,7 +180,7 @@ public class ClientHandler
         catch (Exception e)
         {
             if (client.Server.Config.VerboseExceptionLogging)
-                Globals.PacketLogger.LogError(e.Message + Environment.NewLine + e.StackTrace);
+                client.Logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
         }
         ObjectPool<T>.Shared.Return(packet);
     }


### PR DESCRIPTION
Fixes:
- Global logger being used, causing keepalive to error
- LogLevels
- Player chat not rendering in console correctly
- empty join message in logs