### PR TITLE
Fix source generator localization

### DIFF
--- a/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
+++ b/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using Obsidian.SourceGenerators.Registry.Models;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 
@@ -10,6 +11,8 @@ public sealed partial class RegistryAssetsGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
         var jsonFiles = context.AdditionalTextsProvider
             .Where(file => file.Path.EndsWith(".json"))
             .Select(static (file, ct) => (name: Path.GetFileNameWithoutExtension(file.Path), content: file.GetText(ct)!.ToString()));


### PR DESCRIPTION
Source generator generates code with floating point numbers formatted as `0,1f` (comma instead of dot). This causes many build errors.