### PR TITLE
Obsidian.IO

### DIFF
--- a/Obsidian.IO/IPacketOutput.cs
+++ b/Obsidian.IO/IPacketOutput.cs
@@ -1,0 +1,36 @@
+﻿namespace Obsidian.IO;
+
+/// <summary>
+/// Represents any type to which a packet can be written.
+/// </summary>
+public interface IPacketOutput : IDisposable
+{
+    
+    /// <summary>
+    /// The number of <see cref="byte"/> written to the output.
+    /// </summary>
+    long Written { get; }
+    
+    /// <summary>
+    /// Writes a single <see cref="byte"/> to the output.
+    /// </summary>
+    /// <param name="b"></param>
+    void WriteByte(byte b);
+    
+    /// <summary>
+    /// Writes a <see cref="Span{T}"/> of <see cref="byte"/> to the output.
+    /// </summary>
+    /// <param name="bytes"></param>
+    void WriteBytes(in ReadOnlySpan<byte> bytes);
+
+    /// <summary>
+    /// Tries to get a <see cref="byte"/> <see cref="Span{T}"/> of the specified <paramref name="length"/> from the output buffer, if possible.
+    /// <para>
+    /// The <paramref name="length"/> is committed to <see cref="Written"/> if this method returns <see langword="true"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="length">Length of the buffer to get.</param>
+    /// <param name="buffer">The buffer to write to.</param>
+    /// <returns><see langword="true"/> if the buffer was successfully retrieved, <see langword="false"/> otherwise.</returns>
+    bool TryGetDirectBuffer(int length, out Span<byte> buffer);
+}

--- a/Obsidian.IO/IPacketWritable.cs
+++ b/Obsidian.IO/IPacketWritable.cs
@@ -1,0 +1,9 @@
+﻿namespace Obsidian.IO;
+
+/// <summary>
+/// Helper interface for types that can be written
+/// </summary>
+public interface IPacketWritable
+{
+    void WriteToPacketWriter<O>(ref PacketWriter<O> writer) where O : IPacketOutput;
+}

--- a/Obsidian.IO/Obsidian.IO.csproj
+++ b/Obsidian.IO/Obsidian.IO.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
+    </ItemGroup>
+</Project>

--- a/Obsidian.IO/Outputs/ArrayPacketOutput.cs
+++ b/Obsidian.IO/Outputs/ArrayPacketOutput.cs
@@ -22,14 +22,14 @@ public struct ArrayPacketOutput : IPacketOutput
         written = 0;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteByte(byte b)
     {
         Buffer[written++] = b;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteBytes(in ReadOnlySpan<byte> bytes)
     {
@@ -37,7 +37,7 @@ public struct ArrayPacketOutput : IPacketOutput
         written += bytes.Length;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public bool TryGetDirectBuffer(int length, out Span<byte> buffer) {
         if (written + length > Buffer.Length) {

--- a/Obsidian.IO/Outputs/ArrayPacketOutput.cs
+++ b/Obsidian.IO/Outputs/ArrayPacketOutput.cs
@@ -1,0 +1,55 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Obsidian.IO.Outputs;
+
+/// <summary>
+/// Writes data to the specified <see cref="Buffer"/>, will not resize iit
+/// </summary>
+public struct ArrayPacketOutput : IPacketOutput
+{
+    public byte[] Buffer { get; }
+    
+    public long Written => written;
+
+    private int written;
+    
+    public ReadOnlySpan<byte> WrittenBytes => Buffer.AsSpan(0, written);
+
+
+    public ArrayPacketOutput(byte[] buffer)
+    {
+        Buffer = buffer;
+        written = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteByte(byte b)
+    {
+        Buffer[written++] = b;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteBytes(in ReadOnlySpan<byte> bytes)
+    {
+        bytes.CopyTo(Buffer.AsSpan(written));
+        written += bytes.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public bool TryGetDirectBuffer(int length, out Span<byte> buffer) {
+        if (written + length > Buffer.Length) {
+            buffer = default;
+            return false;
+        }
+        buffer = Buffer.AsSpan(written, length);
+        written += length;
+        return true;
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/Obsidian.IO/Outputs/ArrayPoolPacketOutput.cs
+++ b/Obsidian.IO/Outputs/ArrayPoolPacketOutput.cs
@@ -1,0 +1,90 @@
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Obsidian.IO.Outputs;
+
+/// <summary>
+/// Writes bytes to an <see cref="ArrayPool{T}"/>, written bytes can be accessed through <see cref="WrittenBytes"/>
+/// </summary>
+public struct ArrayPoolPacketOutput : IPacketOutput
+{
+    private byte[] poolBuffer;
+    private int bufferLength;
+
+    public ArrayPool<byte> Pool { get; }
+
+    public ReadOnlySpan<byte> WrittenBytes => poolBuffer.AsSpan(0, bufferLength);
+
+    public long Written => bufferLength;
+
+
+    public ArrayPoolPacketOutput(ArrayPool<byte> pool)
+    {
+        Pool = pool;
+        poolBuffer = Pool.Rent(1);
+        bufferLength = 0;
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteByte(byte b)
+    {
+        if (RequiresGrowth(1)) GrowBuffer();
+        GetTail() = b;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteBytes(in ReadOnlySpan<byte> bytes)
+    {
+        var len = bytes.Length;
+        if (RequiresGrowth(len)) GrowBuffer();
+        var span = MemoryMarshal.CreateSpan(
+            ref GetTail(),
+            len);
+        bytes.CopyTo(span);
+        bufferLength += len;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public bool TryGetDirectBuffer(int length, out Span<byte> buffer)
+    {
+        if (RequiresGrowth(length)) GrowBuffer();
+
+        buffer = MemoryMarshal.CreateSpan(
+            ref GetTail(),
+            length);
+
+        bufferLength += length;
+        return true;
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    private bool RequiresGrowth(int required) => bufferLength + required > this.poolBuffer.Length;
+
+    
+    private void GrowBuffer()
+    {
+        var newBuffer = Pool.Rent(poolBuffer.Length * 2);
+        poolBuffer.CopyTo(newBuffer, 0);
+        Pool.Return(poolBuffer);
+        poolBuffer = newBuffer;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    private ref byte GetTail()
+    {
+        return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(this.poolBuffer), this.bufferLength);
+    }
+
+    public void Dispose()
+    {
+        Pool?.Return(poolBuffer);
+    }
+}

--- a/Obsidian.IO/Outputs/StreamPacketOutput.cs
+++ b/Obsidian.IO/Outputs/StreamPacketOutput.cs
@@ -1,0 +1,50 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Obsidian.IO.Outputs;
+
+/// <summary>
+/// Writes bytes to the specified <see cref="Stream"/>
+/// </summary>
+public struct StreamPacketOutput : IPacketOutput
+{
+    public Stream Stream { get; }
+    private int written;
+
+    public long Written => written;
+
+    public StreamPacketOutput(Stream stream)
+    {
+        Stream = stream;
+        written = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteByte(byte b)
+    {
+        Stream.WriteByte(b);
+        written++;   
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteBytes(in ReadOnlySpan<byte> bytes)
+    {
+        Stream.Write(bytes);
+        written += bytes.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public bool TryGetDirectBuffer(int length, out Span<byte> buffer)
+    {
+        // Ths could work if we make the stream a generic parameter, and check for MemoryStream
+        buffer = default;
+        return false;
+    }
+    
+    public void Dispose()
+    {
+        
+    }
+}

--- a/Obsidian.IO/Outputs/StreamPacketOutput.cs
+++ b/Obsidian.IO/Outputs/StreamPacketOutput.cs
@@ -18,7 +18,7 @@ public struct StreamPacketOutput : IPacketOutput
         written = 0;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteByte(byte b)
     {
@@ -26,7 +26,7 @@ public struct StreamPacketOutput : IPacketOutput
         written++;   
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteBytes(in ReadOnlySpan<byte> bytes)
     {
@@ -34,7 +34,7 @@ public struct StreamPacketOutput : IPacketOutput
         written += bytes.Length;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public bool TryGetDirectBuffer(int length, out Span<byte> buffer)
     {

--- a/Obsidian.IO/PacketWriter.cs
+++ b/Obsidian.IO/PacketWriter.cs
@@ -22,11 +22,11 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
     /// </summary>
     /// <param name="value">The value to write</param>
     /// <typeparam name="T">The type of the value</typeparam>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void Write<T>(in T value) where T : IPacketWritable => value.WriteToPacketWriter(ref this);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     private unsafe void WriteValue<T>(ref T value) where T : unmanaged
     {
@@ -42,7 +42,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     private unsafe void WriteValue<T>(T value) where T : unmanaged
     {
@@ -58,48 +58,48 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteBytes(in Span<byte> bytes) => output.WriteBytes(bytes);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteByte(sbyte b) => WriteUByte((byte)b);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteUByte(byte b) => output.WriteByte(b);
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteShort(short s)
     {
         WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(s) : s);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteUShort(ushort s)
     {
         WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(s) : s);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteInt(int i)
     {
         WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(i) : i);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteLong(long l)
     {
         WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(l) : l);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteFloat(float f)
     {
@@ -108,7 +108,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
             : f);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteDouble(double d)
     {
@@ -117,7 +117,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
             : d);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public unsafe void WriteVarInt(int value)
     {
@@ -141,7 +141,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
         WriteBytes(new Span<byte>(ptr, len));
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public unsafe void WriteVarLong(long value)
     {
@@ -165,14 +165,14 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
         WriteBytes(new Span<byte>(ptr, len));
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteUuid(Guid uuid)
     {
         WriteValue(ref uuid);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteVarString(ReadOnlySpan<char> value)
     {
@@ -187,7 +187,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
         WriteString(value, bytesCount);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     public void WriteShortString(ReadOnlySpan<char> value)
     {
@@ -203,7 +203,7 @@ public struct PacketWriter<TOutput> where TOutput : IPacketOutput
     }
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SkipLocalsInit]
     private void WriteString(ReadOnlySpan<char> value, int bytes)
     {

--- a/Obsidian.IO/PacketWriter.cs
+++ b/Obsidian.IO/PacketWriter.cs
@@ -1,0 +1,221 @@
+﻿using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Obsidian.IO;
+
+public struct PacketWriter<TOutput> where TOutput : IPacketOutput
+{
+    private TOutput output;
+
+    public TOutput Output => output;
+
+
+    public PacketWriter(TOutput output)
+    {
+        this.output = output;
+    }
+
+    /// <summary>
+    /// Writes any value that implements <see cref="IPacketWritable"/>.
+    /// </summary>
+    /// <param name="value">The value to write</param>
+    /// <typeparam name="T">The type of the value</typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void Write<T>(in T value) where T : IPacketWritable => value.WriteToPacketWriter(ref this);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    private unsafe void WriteValue<T>(ref T value) where T : unmanaged
+    {
+        if (output.TryGetDirectBuffer(sizeof(T), out var buffer))
+        {
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(buffer), value);
+        }
+        else
+        {
+            Span<byte> span = stackalloc byte[sizeof(T)];
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(span), value);
+            WriteBytes(span);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    private unsafe void WriteValue<T>(T value) where T : unmanaged
+    {
+        if (output.TryGetDirectBuffer(sizeof(T), out var buffer))
+        {
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(buffer), value);
+        }
+        else
+        {
+            Span<byte> span = stackalloc byte[sizeof(T)];
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(span), value);
+            WriteBytes(span);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteBytes(in Span<byte> bytes) => output.WriteBytes(bytes);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteByte(sbyte b) => WriteUByte((byte)b);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteUByte(byte b) => output.WriteByte(b);
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteShort(short s)
+    {
+        WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(s) : s);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteUShort(ushort s)
+    {
+        WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(s) : s);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteInt(int i)
+    {
+        WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(i) : i);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteLong(long l)
+    {
+        WriteValue(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(l) : l);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteFloat(float f)
+    {
+        WriteValue(BitConverter.IsLittleEndian
+            ? BitConverter.Int32BitsToSingle(BinaryPrimitives.ReverseEndianness(BitConverter.SingleToInt32Bits(f)))
+            : f);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteDouble(double d)
+    {
+        WriteValue(BitConverter.IsLittleEndian
+            ? BitConverter.Int64BitsToDouble(BinaryPrimitives.ReverseEndianness(BitConverter.DoubleToInt64Bits(d)))
+            : d);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public unsafe void WriteVarInt(int value)
+    {
+        var ptr = stackalloc byte[5];
+        var current = ptr;
+
+        var unsigned = (uint)value;
+
+        WRITE_BYTE:
+        *current = (byte)(unsigned & 127);
+        unsigned >>= 7;
+
+        if (unsigned != 0)
+        {
+            *current |= 128;
+            current += 1;
+            goto WRITE_BYTE;
+        }
+
+        var len = (int)(current - ptr) + 1;
+        WriteBytes(new Span<byte>(ptr, len));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public unsafe void WriteVarLong(long value)
+    {
+        var ptr = stackalloc byte[10];
+        var current = ptr;
+
+        var unsigned = (ulong)value;
+
+        WRITE_BYTE:
+        *current = (byte)(unsigned & 127);
+        unsigned >>= 7;
+
+        if (unsigned != 0)
+        {
+            *current |= 128;
+            current += 1;
+            goto WRITE_BYTE;
+        }
+
+        var len = (int)(current - ptr) + 1;
+        WriteBytes(new Span<byte>(ptr, len));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteUuid(Guid uuid)
+    {
+        WriteValue(ref uuid);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteVarString(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty)
+        {
+            WriteVarInt(0);
+            return;
+        }
+
+        var bytesCount = Encoding.UTF8.GetByteCount(value);
+        WriteVarInt(bytesCount);
+        WriteString(value, bytesCount);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    public void WriteShortString(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty)
+        {
+            WriteShort(0);
+            return;
+        }
+
+        var bytesCount = Encoding.UTF8.GetByteCount(value);
+        WriteShort((short)bytesCount);
+        WriteString(value, bytesCount);
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [SkipLocalsInit]
+    private void WriteString(ReadOnlySpan<char> value, int bytes)
+    {
+        if (output.TryGetDirectBuffer(bytes, out var buffer))
+        {
+            Encoding.UTF8.GetBytes(value, buffer);
+        }
+        else
+        {
+            var bytesBuffer = bytes <= 256 ? stackalloc byte[256] : new byte[bytes];
+            Encoding.UTF8.GetBytes(value, bytesBuffer);
+            WriteBytes(bytesBuffer);
+        }
+    }
+}

--- a/Obsidian.sln
+++ b/Obsidian.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Obsidian.ConsoleApp", "Obsidian.ConsoleApp\Obsidian.ConsoleApp.csproj", "{6CC32C2C-C807-40D3-8B2D-9A7B16A36B54}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian.IO", "Obsidian.IO\Obsidian.IO.csproj", "{50D19B41-2DE5-4145-B6D3-85FDC0D71686}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{6CC32C2C-C807-40D3-8B2D-9A7B16A36B54}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CC32C2C-C807-40D3-8B2D-9A7B16A36B54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CC32C2C-C807-40D3-8B2D-9A7B16A36B54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50D19B41-2DE5-4145-B6D3-85FDC0D71686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50D19B41-2DE5-4145-B6D3-85FDC0D71686}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50D19B41-2DE5-4145-B6D3-85FDC0D71686}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50D19B41-2DE5-4145-B6D3-85FDC0D71686}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Initial implementation of the Obsidian.IO package.

Should allow for fast packet writing/reading with little to no overhead.

Right now, only the PacketWriter and some outputs are implemented.

For usage we should first have

- [ ] A clear idea about how the Writer should work.
- [ ] A clear idea about how the Reader should work.
- [ ] Tests.

After that integration could begin, we could begin by

- [ ] Update Serialization/Deserialization methods and generators to use the new package.
- [ ] Replace all usages of MinecraftStream.
- [ ] Deprecate MinecraftStream.