### PR TITLE
Refactor and optimize DataArray

### DIFF
--- a/Obsidian/ChunkData/BiomeContainer.cs
+++ b/Obsidian/ChunkData/BiomeContainer.cs
@@ -7,7 +7,7 @@ public sealed class BiomeContainer : DataContainer<Biome>
 {
     public override IPalette<Biome> Palette { get; internal set; }
 
-    public override DataArray DataArray { get; protected set; }
+    internal override DataArray DataArray { get; private protected set; }
 
     internal BiomeContainer(byte bitsPerEntry = 2)
     {

--- a/Obsidian/ChunkData/BlockStateContainer.cs
+++ b/Obsidian/ChunkData/BlockStateContainer.cs
@@ -10,7 +10,7 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
 
     public bool IsEmpty => DataArray.storage.Length == 0;
 
-    public override DataArray DataArray { get; protected set; }
+    internal override DataArray DataArray { get; private protected set; }
 
 
 #if CACHE_VALID_BLOCKS

--- a/Obsidian/ChunkData/DataContainer.cs
+++ b/Obsidian/ChunkData/DataContainer.cs
@@ -8,7 +8,7 @@ public abstract class DataContainer<T>
 
     public abstract IPalette<T> Palette { get; internal set; }
 
-    public abstract DataArray DataArray { get; protected set; }
+    internal abstract DataArray DataArray { get; private protected set; }
 
     public virtual int GetIndex(int x, int y, int z) => (y << this.BitsPerEntry | z) << this.BitsPerEntry | x;
 


### PR DESCRIPTION
Breaking changes:
- `DataArray` is now `internal`
- `Capacity` is renamed to `Length` (we may consider `Count` as more idiomatic)

Optimizations:
- replacing division with multiplication + shift lowered time for getting a value to ~`0.25` of the original and setting a value to ~`0.4` of the original.