### PR TITLE
Prevent cancelled events from being un-cancelled

### DIFF
--- a/Obsidian.API/Events/AsyncEventArgs.cs
+++ b/Obsidian.API/Events/AsyncEventArgs.cs
@@ -6,7 +6,15 @@
 public abstract class AsyncEventArgs : EventArgs
 {
     /// <summary>
-    /// Gets or sets whether the event was completely handled. Setting this to true will prevent remaining handlers from running.
+    /// Gets a value indicating whether the event was completely handled.
     /// </summary>
-    public bool Handled { get; set; }
+    public bool Handled { get; private set; }
+
+    /// <summary>
+    /// Marks an event as handled. Setting this flag will prevent remaining handlers from running.
+    /// </summary>
+    public void SetHandled()
+    {
+        Handled = true;
+    }
 }

--- a/Obsidian.API/Events/BlockBreakEventArgs.cs
+++ b/Obsidian.API/Events/BlockBreakEventArgs.cs
@@ -8,10 +8,16 @@ public class BlockBreakEventArgs : BlockEventArgs, ICancellable
     public IPlayer Player { get; }
 
     /// <inheritdoc/>
-    public bool Cancel { get; set; }
+    public bool IsCancelled { get; private set; }
 
     internal BlockBreakEventArgs(IServer server, IPlayer player, IBlock block, Vector location) : base(server, block, location)
     {
         Player = player;
+    }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
     }
 }

--- a/Obsidian.API/Events/ContainerClickEventArgs.cs
+++ b/Obsidian.API/Events/ContainerClickEventArgs.cs
@@ -17,11 +17,18 @@ public class ContainerClickEventArgs : PlayerEventArgs, ICancellable
     /// </summary>
     public int Slot { get; set; }
 
-    public bool Cancel { get; set; }
+    /// <inheritdoc />
+    public bool IsCancelled { get; private set; }
 
     internal ContainerClickEventArgs(IPlayer player, BaseContainer container, ItemStack item) : base(player)
     {
         this.Container = container;
         this.Item = item;
+    }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
     }
 }

--- a/Obsidian.API/Events/EntityEventArgs.cs
+++ b/Obsidian.API/Events/EntityEventArgs.cs
@@ -7,10 +7,17 @@ public class EntityEventArgs : BaseMinecraftEventArgs, ICancellable
     /// </summary>
     public IEntity Entity { get; }
 
-    public bool Cancel { get; set; }
+    /// <inheritdoc />
+    public bool IsCancelled { get; private set; }
 
     public EntityEventArgs(IEntity entity, IServer server) : base(server)
     {
         this.Entity = entity;
+    }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
     }
 }

--- a/Obsidian.API/Events/ICancellable.cs
+++ b/Obsidian.API/Events/ICancellable.cs
@@ -6,7 +6,13 @@
 public interface ICancellable
 {
     /// <summary>
-    /// Gets or sets a value indicating whether the default behaviour should be cancelled.
+    /// Gets a value indicating whether the default behaviour should be cancelled.
     /// </summary>
-    public bool Cancel { get; set; }
+    public bool IsCancelled { get; }
+
+    /// <summary>
+    /// Sets a flag which prevents default (vanilla) behavior from executing.
+    /// </summary>
+    /// <remarks>This flag only affects vanilla behavior. If you wish to prevent other handlers from running, see <see cref="AsyncEventArgs.IsHandled"/>.</remarks>
+    public void Cancel();
 }

--- a/Obsidian.API/Events/IncomingChatMessageEventArgs.cs
+++ b/Obsidian.API/Events/IncomingChatMessageEventArgs.cs
@@ -12,11 +12,24 @@ public class IncomingChatMessageEventArgs : PlayerEventArgs, ICancellable
     /// </summary>
     public string Format { get; set; }
 
-    public bool Cancel { get; set; }
+    /// <inheritdoc />
+    public bool IsCancelled { get; private set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IncomingChatMessageEventArgs"/> class.
+    /// </summary>
+    /// <param name="player">The player which sent the message.</param>
+    /// <param name="message">The message which was sent.</param>
+    /// <param name="format">Any formatting appied to the message.</param>
     public IncomingChatMessageEventArgs(IPlayer player, string message, string format) : base(player)
     {
         this.Message = message;
         this.Format = format;
+    }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
     }
 }

--- a/Obsidian.API/Events/PacketReceivedEventArgs.cs
+++ b/Obsidian.API/Events/PacketReceivedEventArgs.cs
@@ -12,10 +12,11 @@ public sealed class PacketReceivedEventArgs : PlayerEventArgs, ICancellable
     /// </summary>
     public ReadOnlyMemory<byte> Data { get; }
 
-    /// <summary>
+    /// <inheritdoc />
+    /// <remarks>
     /// If true, packet will be ignored by the server.
-    /// </summary>
-    public bool Cancel { get; set; }
+    /// </remarks>
+    public bool IsCancelled { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PacketReceivedEventArgs"/> class
@@ -28,5 +29,11 @@ public sealed class PacketReceivedEventArgs : PlayerEventArgs, ICancellable
     {
         Id = id;
         Data = data;
+    }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
     }
 }

--- a/Obsidian.API/Events/PlayerInteractEventArgs.cs
+++ b/Obsidian.API/Events/PlayerInteractEventArgs.cs
@@ -22,7 +22,14 @@ public sealed class PlayerInteractEventArgs : PlayerEventArgs, ICancellable
     /// </summary>
     public Vector? BlockLocation { get; init; }
 
-    public bool Cancel { get; set; }
+    /// <inheritdoc />
+    public bool IsCancelled { get; private set; }
 
     public PlayerInteractEventArgs(IPlayer player) : base(player) { }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
+    }
 }

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -309,7 +309,7 @@ public sealed class Client : IDisposable
                     var packetReceivedEventArgs = new PacketReceivedEventArgs(Player, id, data);
                     await Server.Events.InvokePacketReceivedAsync(packetReceivedEventArgs);
 
-                    if (!packetReceivedEventArgs.Cancel)
+                    if (!packetReceivedEventArgs.IsCancelled)
                     {
                         await handler.HandlePlayPackets(id, data, this);
                     }
@@ -727,7 +727,7 @@ public sealed class Client : IDisposable
     internal async Task QueuePacketAsync(IClientboundPacket packet)
     {
         var args = await Server.Events.InvokeQueuePacketAsync(new QueuePacketEventArgs(this, packet));
-        if (args.Cancel)
+        if (args.IsCancelled)
         {
             Logger.LogDebug("Packet {PacketId} was sent to the queue, however an event handler registered in {Name} has cancelled it.", args.Packet.Id, nameof(Server.Events));
         }

--- a/Obsidian/Events/EventArgs/QueuePacketEventArgs.cs
+++ b/Obsidian/Events/EventArgs/QueuePacketEventArgs.cs
@@ -5,7 +5,14 @@ namespace Obsidian.Events.EventArgs;
 
 public class QueuePacketEventArgs : BasePacketEventArgs, ICancellable
 {
-    public bool Cancel { get; set; }
+    /// <inheritdoc />
+    public bool IsCancelled { get; private set; }
 
     internal QueuePacketEventArgs(Client client, IPacket packet) : base(client, packet) { }
+
+    /// <inheritdoc />
+    public void Cancel()
+    {
+        IsCancelled = true;
+    }
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
@@ -276,7 +276,7 @@ public partial class ClickContainerPacket : IServerboundPacket
                 Slot = slot
             });
 
-            if (@event.Cancel)
+            if (@event.IsCancelled)
                 return;
 
             player.LastClickedItem = CarriedItem;

--- a/Obsidian/Net/Packets/Play/Serverbound/PlayerActionPacket.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/PlayerActionPacket.cs
@@ -32,7 +32,7 @@ public partial class PlayerActionPacket : IServerboundPacket
             await player.World.SetBlockUntrackedAsync(Position, BlocksRegistry.Air, true);
 
             var blockBreakEvent = await server.Events.InvokeBlockBreakAsync(new BlockBreakEventArgs(server, player, block, Position));
-            if (blockBreakEvent.Cancel)
+            if (blockBreakEvent.IsCancelled)
                 return;
         }
 

--- a/Obsidian/Server.Events.cs
+++ b/Obsidian/Server.Events.cs
@@ -28,7 +28,7 @@ public partial class Server
         var server = e.Server as Server;
         var player = e.Player as Player;
 
-        if (e.Cancel)
+        if (e.IsCancelled)
             return;
 
         if (block is not null)

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -443,7 +443,7 @@ public partial class Server : IServer
         var message = packet.Message;
 
         var chat = await Events.InvokeIncomingChatMessageAsync(new IncomingChatMessageEventArgs(source.Player, message, format));
-        if (chat.Cancel)
+        if (chat.IsCancelled)
             return;
 
         //TODO add bool for sending secure chat messages


### PR DESCRIPTION
Fixes #342 

Overview of changes:
1. Modify `ICancellable` interface to remove setter on Cancel property.
2. Rename ICancellable.Cancel to ICancellable.IsCancelled. Hopefully this doesn't cause any issues with reflection somewhere that I'm not aware of.
3. Add ICancellable.Cancel().
4. Perform similar changes (without rename) on AsyncEventArgs so events cannot be un-handled. We can cancel this change but I felt it was good to be consistent.
5. Update consumers of ICancellable