### PR TITLE
Seal virtual object methods in PluginBase

### DIFF
--- a/Obsidian.API/Plugins/PluginBase.cs
+++ b/Obsidian.API/Plugins/PluginBase.cs
@@ -236,4 +236,8 @@ public abstract class PluginBase
 
         return (null, -1);
     }
+
+    public override sealed bool Equals(object? obj) => base.Equals(obj);
+    public override sealed int GetHashCode() => base.GetHashCode();
+    public override sealed string ToString() => Info?.Name ?? GetType().Name;
 }


### PR DESCRIPTION
This serves as a preparation for future plugin changes. Firstly, we ensure that behaviour of these methods is consistent for all plugins (plugins can't override it further) and secondly it improves plugin developer experience, as IDEs will only offer (via code completion) to override virtual methods that are offered to Obsidian plugins.