### PR TITLE
Add methods for finding entities and players in range

### DIFF
--- a/Obsidian/Entities/Entity.cs
+++ b/Obsidian/Entities/Entity.cs
@@ -287,7 +287,7 @@ public class Entity : IEquatable<Entity>, IEntity
         stream.WriteVarInt(PowderedSnowTicks);
     }
 
-    public IEnumerable<IEntity> GetEntitiesNear(float distance) => world.GetEntitiesNear(Position, distance).Where(x => x != this);
+    public IEnumerable<IEntity> GetEntitiesNear(float distance) => world.GetEntitiesInRange(Position, distance).Where(x => x != this);
 
     public virtual Task TickAsync() => Task.CompletedTask;
 

--- a/Obsidian/Entities/ItemEntity.cs
+++ b/Obsidian/Entities/ItemEntity.cs
@@ -42,7 +42,7 @@ public partial class ItemEntity : Entity
         if (!CanPickup && this.TimeDropped.Subtract(DateTimeOffset.UtcNow).TotalSeconds > 5)
             this.CanPickup = true;
 
-        foreach (var ent in this.world.GetEntitiesNear(this.Position, 1.5f))
+        foreach (var ent in this.world.GetEntitiesInRange(this.Position, 1.5f))
         {
             if (ent is ItemEntity item)
             {

--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -321,7 +321,7 @@ public sealed partial class Player : Living, IPlayer
     public Task KickAsync(string reason) => client.DisconnectAsync(ChatMessage.Simple(reason));
     public Task KickAsync(ChatMessage reason) => client.DisconnectAsync(reason);
 
-    public async Task RespawnAsync(DataKept dataKept = DataKept.Metadata)
+    public async Task RespawnAsync(bool copyMetadata = false)
     {
         if (!Alive)
         {
@@ -344,7 +344,7 @@ public sealed partial class Player : Living, IPlayer
             HashedSeed = 0,
             IsFlat = false,
             IsDebug = false,
-            DataKept = dataKept
+            CopyMetadata = copyMetadata
         });
 
         visiblePlayers.Clear();
@@ -897,7 +897,7 @@ public sealed partial class Player : Living, IPlayer
 
     private async Task PickupNearbyItemsAsync(float distance = 0.5f)
     {
-        foreach (var entity in world.GetEntitiesNear(Position, distance))
+        foreach (var entity in world.GetEntitiesInRange(Position, distance))
         {
             if (entity is not ItemEntity item)
                 continue;

--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -321,7 +321,7 @@ public sealed partial class Player : Living, IPlayer
     public Task KickAsync(string reason) => client.DisconnectAsync(ChatMessage.Simple(reason));
     public Task KickAsync(ChatMessage reason) => client.DisconnectAsync(reason);
 
-    public async Task RespawnAsync(bool copyMetadata = false)
+    public async Task RespawnAsync(DataKept dataKept = DataKept.Metadata)
     {
         if (!Alive)
         {
@@ -344,7 +344,7 @@ public sealed partial class Player : Living, IPlayer
             HashedSeed = 0,
             IsFlat = false,
             IsDebug = false,
-            CopyMetadata = copyMetadata
+            DataKept = dataKept
         });
 
         visiblePlayers.Clear();

--- a/Obsidian/Entities/Player.cs
+++ b/Obsidian/Entities/Player.cs
@@ -12,6 +12,7 @@ using Obsidian.WorldData;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Net;
 
 namespace Obsidian.Entities;
@@ -867,12 +868,11 @@ public sealed partial class Player : Living, IPlayer
 
     private async Task TrySpawnPlayerAsync(VectorF position)
     {
-        var players = world.Players
-            .Except(Uuid)
-            .Where(x => VectorF.Distance(position, x.Value.Position) <= x.Value.ClientInformation.ViewDistance);
-
-        foreach (var (_, player) in players)
+        foreach (var player in world.GetPlayersInRange(position, ClientInformation.ViewDistance))
         {
+            if (player == this)
+                continue;
+
             if (player.Alive && !visiblePlayers.Contains(player.EntityId))
             {
                 visiblePlayers.Add(player.EntityId);
@@ -897,7 +897,7 @@ public sealed partial class Player : Living, IPlayer
 
     private async Task PickupNearbyItemsAsync(float distance = 0.5f)
     {
-        foreach (var entity in world.GetEntitiesInRange(Position, distance))
+        foreach (var entity in world.GetNonPlayerEntitiesInRange(Position, distance))
         {
             if (entity is not ItemEntity item)
                 continue;


### PR DESCRIPTION
World now has methods to not only find entities+players in range, but also one without the other (`GetNonPlayerEntitiesInRange` and `GetPlayersInRange`). Finding entities changed behaviour - more than just the nearest region is checked now (which should be the correct behaviour).

TODO Test the implementation