### PR TITLE
Migrate to use `Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets`

### DIFF
--- a/Obsidian/Commands/MainCommandModule.cs
+++ b/Obsidian/Commands/MainCommandModule.cs
@@ -328,14 +328,12 @@ public class MainCommandModule
     [Command("stop")]
     [CommandInfo("Stops the server.", "/stop")]
     [RequirePermission(permissions: "obsidian.stop")]
-    public Task StopAsync(CommandContext ctx)
+    public async Task StopAsync(CommandContext ctx)
     {
         var server = (Server)ctx.Server;
         server.BroadcastMessage($"Stopping server...");
 
-        server.Stop();
-
-        return Task.CompletedTask;
+        await server.StopAsync();
     }
 
     [Command("time")]

--- a/Obsidian/Net/DuplexPipeStream.cs
+++ b/Obsidian/Net/DuplexPipeStream.cs
@@ -1,0 +1,139 @@
+﻿using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+
+namespace Obsidian.Net;
+
+// https://raw.githubusercontent.com/StarlkYT/BedrockFramework/main/src/Bedrock.Framework/Infrastructure/DuplexPipeStream.cs
+// With some small changes.
+internal sealed class DuplexPipeStream : Stream
+{
+    private readonly PipeReader _input;
+    private readonly PipeWriter _output;
+    private readonly bool _throwOnCancelled;
+    private volatile bool _cancelCalled;
+
+    public DuplexPipeStream(IDuplexPipe pipe, bool throwOnCancelled = false)
+    {
+        _input = pipe.Input;
+        _output = pipe.Output;
+        _throwOnCancelled = throwOnCancelled;
+    }
+
+    public void CancelPendingRead()
+    {
+        _cancelCalled = true;
+        _input.CancelPendingRead();
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => true;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        // ValueTask uses .GetAwaiter().GetResult() if necessary
+        // https://github.com/dotnet/corefx/blob/f9da3b4af08214764a51b2331f3595ffaf162abe/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs#L156
+        return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), default).Result;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+        CancellationToken cancellationToken)
+    {
+        return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+    {
+        return ReadAsyncInternal(destination, cancellationToken);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+    }
+
+    public async override Task WriteAsync(byte[]? buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (buffer != null)
+        {
+            _output.Write(new ReadOnlySpan<byte>(buffer, offset, count));
+        }
+
+        await _output.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async override ValueTask WriteAsync(ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        _output.Write(source.Span);
+        await _output.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void Flush()
+    {
+        FlushAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        return WriteAsync(null, 0, 0, cancellationToken);
+    }
+
+    private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var result = await _input.ReadAsync(cancellationToken).ConfigureAwait(false);
+            var readableBuffer = result.Buffer;
+            try
+            {
+                if (_throwOnCancelled && result.IsCanceled && _cancelCalled)
+                {
+                    // Reset the bool
+                    _cancelCalled = false;
+                    throw new OperationCanceledException();
+                }
+
+                if (!readableBuffer.IsEmpty)
+                {
+                    // buffer.Count is int
+                    var count = (int)Math.Min(readableBuffer.Length, destination.Length);
+                    readableBuffer = readableBuffer.Slice(0, count);
+                    readableBuffer.CopyTo(destination.Span);
+                    return count;
+                }
+
+                if (result.IsCompleted)
+                {
+                    return 0;
+                }
+            }
+            finally
+            {
+                _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+            }
+        }
+    }
+}

--- a/Obsidian/Net/SocketFactory.cs
+++ b/Obsidian/Net/SocketFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Threading;
+
+namespace Obsidian.Net;
+
+internal static class SocketFactory
+{
+    public static async Task<IConnectionListener> CreateListenerAsync(IPEndPoint endPoint, SocketTransportOptions? options = null, 
+        ILoggerFactory? loggerFactory = null, CancellationToken token = default)
+    {
+        options ??= new SocketTransportOptions();
+        loggerFactory ??= NullLoggerFactory.Instance;
+        
+        var factory = new SocketTransportFactory(Options.Create(options), loggerFactory);
+        return await factory.BindAsync(endPoint, token);
+    }
+}

--- a/Obsidian/Obsidian.csproj
+++ b/Obsidian/Obsidian.csproj
@@ -55,6 +55,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.7" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Obsidian.API.Boss;
@@ -12,6 +13,7 @@ using Obsidian.Concurrency;
 using Obsidian.Entities;
 using Obsidian.Events;
 using Obsidian.Hosting;
+using Obsidian.Net;
 using Obsidian.Net.Packets;
 using Obsidian.Net.Packets.Play.Clientbound;
 using Obsidian.Net.Packets.Play.Serverbound;
@@ -56,10 +58,11 @@ public partial class Server : IServer
 
     private readonly ConcurrentQueue<IClientboundPacket> _chatMessagesQueue = new();
     private readonly ConcurrentHashSet<Client> _clients = new();
-    private readonly TcpListener _tcpListener;
     private readonly RconServer _rconServer;
     private readonly ILogger _logger;
 
+    private IConnectionListener? _tcpListener;
+    
     public ProtocolVersion Protocol => DefaultProtocol;
 
     public int Tps { get; private set; }
@@ -109,8 +112,6 @@ public partial class Server : IServer
         Config = environment.Configuration;
         Port = Config.Port;
         ServerFolderPath = Directory.GetCurrentDirectory();
-
-        _tcpListener = new TcpListener(IPAddress.Any, Port);
 
         Operators = new OperatorList(this);
 
@@ -258,7 +259,7 @@ public partial class Server : IServer
         if (Config.MulitplayerDebugMode && Config.OnlineMode)
         {
             _logger.LogError("Incompatible Config: Multiplayer debug mode can't be enabled at the same time as online mode since usernames will be overwritten");
-            Stop();
+            await StopAsync();
             return;
         }
 
@@ -333,14 +334,21 @@ public partial class Server : IServer
 
     private async Task AcceptClientsAsync()
     {
-        _tcpListener.Start();
+        _tcpListener = await SocketFactory.CreateListenerAsync(new IPEndPoint(IPAddress.Any, Port), token: _cancelTokenSource.Token);
 
         while (!_cancelTokenSource.Token.IsCancellationRequested)
         {
-            Socket socket;
+            ConnectionContext socket;
             try
             {
-                socket = await _tcpListener.AcceptSocketAsync(_cancelTokenSource.Token);
+                var connection = await _tcpListener.AcceptAsync(_cancelTokenSource.Token);
+                if (connection is null)
+                {
+                    // No longer accepting clients.
+                    break;
+                }
+
+                socket = connection;
             }
             catch (OperationCanceledException)
             {
@@ -360,7 +368,7 @@ public partial class Server : IServer
             if (Config.IpWhitelistEnabled && !Config.WhitelistedIPs.Contains(ip))
             {
                 _logger.LogInformation("{ip} is not whitelisted. Closing connection", ip);
-                await socket.DisconnectAsync(false);
+                socket.Abort();
                 return;
             }
 
@@ -390,7 +398,7 @@ public partial class Server : IServer
         }
 
         _logger.LogInformation("No longer accepting new clients");
-        _tcpListener.Stop();
+        await _tcpListener.UnbindAsync();
     }
 
     public IBossBar CreateBossBar(ChatMessage title, float health, BossBarColor color, BossBarDivisionType divisionType, BossBarFlags flags) => new BossBar(this)
@@ -629,10 +637,15 @@ public partial class Server : IServer
         }
     }
 
-    public void Stop()
+    public async Task StopAsync()
     {
         _cancelTokenSource.Cancel();
-        _tcpListener.Stop();
+        
+        if (_tcpListener is not null)
+        {
+            await _tcpListener.UnbindAsync();
+        }
+        
         WorldGenerators.Clear();
         foreach (var client in _clients)
         {

--- a/Obsidian/Utilities/Extensions.cs
+++ b/Obsidian/Utilities/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using Obsidian.Entities;
+﻿using Microsoft.AspNetCore.Connections;
+using Obsidian.Entities;
 using Obsidian.Registries;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -84,6 +85,12 @@ public static partial class Extensions
         }
     }
 
+    // Just to make stuff easier.
+    public static bool IsConnected(this ConnectionContext context)
+    {
+        return !context.ConnectionClosed.IsCancellationRequested;
+    }
+    
     // Derived from https://gist.github.com/ammaraskar/7b4a3f73bee9dc4136539644a0f27e63
     [SuppressMessage("Roslyn", "CA5350", Justification = "SHA1 is required by the Minecraft protocol.")]
     public static string MinecraftShaDigest(this IEnumerable<byte> data)


### PR DESCRIPTION
Currently Obsidian uses the `TcpListener` for the server and raw `Socket` for the client. While those classes do the job, the issue #96 raises a concern about performance due to the fact that the currently used classes do not make use of the optimized ways for data receiving and sending. I benchmarked the login state sequence, before using the PR and after. The server averaged at 841140 ticks after the PR, and 934719 ticks before. (Results are not 100% accurate), it can also be significantly improved if we start using `System.IO.Pipelines`, and this PR is a step towards that. 

