### PR TITLE
Tear down dependencies on loggers

### DIFF
--- a/Obsidian.API/Logging/Logger.cs
+++ b/Obsidian.API/Logging/Logger.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
-using Obsidian.API;
-using Obsidian.Utilities;
+using Obsidian.API.Utilities;
 using System.Diagnostics;
 
-namespace Obsidian.ConsoleApp.Logging;
+namespace Obsidian.API.Logging;
 
-public class Logger : ILogger<Server>
+public class Logger : ILogger
 {
     protected static readonly object _lock = new();
 

--- a/Obsidian.API/Logging/LoggerProvider.cs
+++ b/Obsidian.API/Logging/LoggerProvider.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
-namespace Obsidian.ConsoleApp.Logging;
+namespace Obsidian.API.Logging;
 
-public sealed class LoggerProvider : ILoggerProvider
+public class LoggerProvider : ILoggerProvider
 {
     private ConcurrentDictionary<string, Logger> loggers = new();
 
@@ -11,7 +11,7 @@ public sealed class LoggerProvider : ILoggerProvider
 
     private bool disposed = false;
 
-    internal LoggerProvider(LogLevel minLevel = LogLevel.Information)
+    public LoggerProvider(LogLevel minLevel = LogLevel.Information)
     {
         MinimumLevel = minLevel;
     }

--- a/Obsidian.API/Obsidian.API.csproj
+++ b/Obsidian.API/Obsidian.API.csproj
@@ -53,6 +53,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
 		<PackageReference Include="SharpNoise" Version="0.12.1.1" />
 	</ItemGroup>
 

--- a/Obsidian.API/Utilities/ConsoleIO.cs
+++ b/Obsidian.API/Utilities/ConsoleIO.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 
-namespace Obsidian.Utilities;
+namespace Obsidian.API.Utilities;
 
 /// <summary>
 /// Allows simultaneous console input and output without breaking user input

--- a/Obsidian.API/Utilities/Extensions.Colors.cs
+++ b/Obsidian.API/Utilities/Extensions.Colors.cs
@@ -1,4 +1,4 @@
-﻿namespace Obsidian.Utilities;
+﻿namespace Obsidian.API.Utilities;
 
 public static partial class Extensions
 {

--- a/Obsidian.API/Utilities/Extensions.StringManipulation.cs
+++ b/Obsidian.API/Utilities/Extensions.StringManipulation.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
-namespace Obsidian.Utilities;
+namespace Obsidian.API.Utilities;
 
 public static partial class Extensions
 {

--- a/Obsidian.API/Utilities/Extensions.cs
+++ b/Obsidian.API/Utilities/Extensions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 
 namespace Obsidian.API.Utilities;
-public static class Extensions
+public static partial class Extensions
 {
     public static List<string> GetStateValues(this string key, Dictionary<string, string[]> valueStores)
     {

--- a/Obsidian.ConsoleApp/Program.cs
+++ b/Obsidian.ConsoleApp/Program.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Obsidian.ConsoleApp.Logging;
+using Obsidian.API.Logging;
+using Obsidian.API.Utilities;
 using Obsidian.Hosting;
-using Obsidian.Utilities;
 
 namespace Obsidian.ConsoleApp;
 

--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Obsidian.API.Events;
+using Obsidian.API.Logging;
+using Obsidian.API.Utilities;
 using Obsidian.Concurrency;
 using Obsidian.Entities;
 using Obsidian.Events.EventArgs;
@@ -148,7 +150,7 @@ public sealed class Client : IDisposable
     /// <summary>
     /// Used to log actions caused by the client.
     /// </summary>
-    public ILogger Logger => Server.Logger;
+    protected ILogger Logger { get; private set; }
 
     /// <summary>
     /// The player that the client is logged in as.
@@ -169,6 +171,9 @@ public sealed class Client : IDisposable
     {
         this.connectionContext = connectionContext;
         this.config = config;
+        var loggerProvider = new LoggerProvider(config.LogLevel);
+        Logger = loggerProvider.CreateLogger("Client");
+
         id = playerId;
         Server = originServer;
 
@@ -575,7 +580,7 @@ public sealed class Client : IDisposable
     {
         if (!missedKeepAlives.Contains(keepAlive.KeepAliveId))
         {
-            Server.Logger.LogWarning($"Received invalid KeepAlive from {Player.Username}?? Naughty???? ({Player.Uuid})");
+            Logger.LogWarning($"Received invalid KeepAlive from {Player.Username}?? Naughty???? ({Player.Uuid})");
             DisconnectAsync(ChatMessage.Simple("Kicked for invalid KeepAlive."));
             return;
         }

--- a/Obsidian/Commands/MainCommandModule.cs
+++ b/Obsidian/Commands/MainCommandModule.cs
@@ -1,3 +1,4 @@
+using Obsidian.API.Utilities;
 using Obsidian.Commands.Framework.Entities;
 using Obsidian.Entities;
 using Obsidian.Registries;

--- a/Obsidian/Globals.cs
+++ b/Obsidian/Globals.cs
@@ -1,4 +1,5 @@
-﻿using Obsidian.Utilities.Converters;
+﻿using Obsidian.API.Utilities;
+using Obsidian.Utilities.Converters;
 using System.Net.Http;
 using System.Text.Encodings.Web;
 using System.Text.Json;

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -1,4 +1,5 @@
-﻿using Obsidian.Commands;
+﻿using Obsidian.API.Utilities;
+using Obsidian.Commands;
 using Obsidian.Nbt;
 using Obsidian.Registries;
 using Obsidian.Serialization.Attributes;

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -2,6 +2,7 @@
 using Obsidian.API.Crafting;
 using Obsidian.API.Inventory;
 using Obsidian.API.Registry.Codecs.Dimensions;
+using Obsidian.API.Utilities;
 using Obsidian.Commands;
 using Obsidian.Entities;
 using Obsidian.Nbt;
@@ -12,7 +13,6 @@ using Obsidian.Net.WindowProperties;
 using Obsidian.Registries;
 using Obsidian.Serialization.Attributes;
 using System.Buffers.Binary;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Obsidian.Net;

--- a/Obsidian/Net/Packets/Play/Clientbound/ChunkDataAndUpdateLightPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/ChunkDataAndUpdateLightPacket.cs
@@ -1,4 +1,5 @@
-﻿using Obsidian.Nbt;
+﻿using Obsidian.API.Utilities;
+using Obsidian.Nbt;
 using Obsidian.WorldData;
 
 namespace Obsidian.Net.Packets.Play.Clientbound;

--- a/Obsidian/Net/Packets/Play/Serverbound/ChatCommandPacket.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/ChatCommandPacket.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Logging;
 using Obsidian.Commands;
 using Obsidian.Commands.Framework.Entities;
 using Obsidian.Entities;
@@ -27,14 +28,16 @@ public partial class ChatCommandPacket : IServerboundPacket
 
     public async ValueTask HandleAsync(Server server, Player player)
     {
-        var context = new CommandContext($"/{this.Command}", new CommandSender(CommandIssuers.Client, player, server.Logger), player, server);
+        var loggerProvider = new LoggerProvider(LogLevel.Error);
+        var logger = loggerProvider.CreateLogger("ChatCommandPacket");
+        var context = new CommandContext($"/{this.Command}", new CommandSender(CommandIssuers.Client, player, logger), player, server);
         try
         {
             await server.CommandsHandler.ProcessCommand(context);
         }
         catch (Exception e)
         {
-            server.Logger.LogError(e, e.Message);
+            logger.LogError(e, e.Message);
         }
     }
 }

--- a/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
@@ -292,7 +292,6 @@ public partial class ClickContainerPacket : IServerboundPacket
         {
             if (Button == 0)
             {
-                server.Logger.LogDebug("Placed: {} in container: {}", player.LastClickedItem?.Type, container.Title?.Text);
                 container.SetItem(slot, player.LastClickedItem);
 
                 player.LastClickedItem = CarriedItem;

--- a/Obsidian/Registries/ItemsRegistry.cs
+++ b/Obsidian/Registries/ItemsRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using Obsidian.API.Crafting;
+using Obsidian.API.Utilities;
 
 namespace Obsidian.Registries;
 public partial class ItemsRegistry

--- a/Obsidian/ScoreboardManager.cs
+++ b/Obsidian/ScoreboardManager.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Logging;
 
 namespace Obsidian;
 
@@ -19,8 +20,10 @@ public sealed class ScoreboardManager : IScoreboardManager
 
     public IScoreboard CreateScoreboard(string name)
     {
+        var loggerProvider = new LoggerProvider(LogLevel.Warning);
+        var logger = loggerProvider.CreateLogger("ScoreboardManager");
         if (!this.scoreboards.Add(name))
-            this.server.Logger.LogWarning($"Scoreboard with the name: {name} already exists. This might cause some issues and override already existing scoreboards displaying on clients.");
+            logger.LogWarning($"Scoreboard with the name: {name} already exists. This might cause some issues and override already existing scoreboards displaying on clients.");
 
         return new Scoreboard(name, this.server);
     }

--- a/Obsidian/Server.Events.cs
+++ b/Obsidian/Server.Events.cs
@@ -1,6 +1,7 @@
 ﻿using Obsidian.API.Builders;
 using Obsidian.API.Containers;
 using Obsidian.API.Events;
+using Obsidian.API.Utilities;
 using Obsidian.Entities;
 using Obsidian.Nbt;
 using Obsidian.Net.Packets.Play.Clientbound;

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -77,84 +77,84 @@ public class ClientHandler
         switch (id)
         {
             case 0x00:
-                await HandleFromPoolAsync<ConfirmTeleportationPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ConfirmTeleportationPacket>(data, client);
                 break;
             case 0x04:
-                await HandleFromPoolAsync<ChatCommandPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ChatCommandPacket>(data, client);
                 break;
             case 0x05:
-                await HandleFromPoolAsync<ChatMessagePacket>(data, client, _logger);
+                await HandleFromPoolAsync<ChatMessagePacket>(data, client);
                 break;
             case 0x06:
-                await HandleFromPoolAsync<PlayerSessionPacket>(data, client, _logger);
+                await HandleFromPoolAsync<PlayerSessionPacket>(data, client);
                 break;
             case 0x07:
-                await HandleFromPoolAsync<ClientCommandPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ClientCommandPacket>(data, client);
                 break;
             case 0x08:
-                await HandleFromPoolAsync<ClientInformationPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ClientInformationPacket>(data, client);
                 break;
             case 0x0A:
-                await HandleFromPoolAsync<ClickContainerButtonPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ClickContainerButtonPacket>(data, client);
                 break;
 
             case 0x0B:
-                await HandleFromPoolAsync<ClickContainerPacket>(data, client, _logger);
+                await HandleFromPoolAsync<ClickContainerPacket>(data, client);
                 break;
 
             case 0x0C:
-                await HandleFromPoolAsync<CloseContainerPacket>(data, client, _logger);
+                await HandleFromPoolAsync<CloseContainerPacket>(data, client);
                 break;
 
             case 0x0D:
-                await HandleFromPoolAsync<PluginMessagePacket>(data, client, _logger);
+                await HandleFromPoolAsync<PluginMessagePacket>(data, client);
                 break;
 
             case 0x10:
-                await HandleFromPoolAsync<InteractPacket>(data, client, _logger);
+                await HandleFromPoolAsync<InteractPacket>(data, client);
                 break;
 
             case 0x12:
-                await HandleFromPoolAsync<KeepAlivePacket>(data, client, _logger);
+                await HandleFromPoolAsync<KeepAlivePacket>(data, client);
                 break;
 
             case 0x1A:
-                await HandleFromPoolAsync<PickItemPacket>(data, client, _logger);
+                await HandleFromPoolAsync<PickItemPacket>(data, client);
                 break;
 
             case 0x1B:
-                await HandleFromPoolAsync<PlaceRecipePacket>(data, client, _logger);
+                await HandleFromPoolAsync<PlaceRecipePacket>(data, client);
                 break;
 
             case 0x1D:
-                await HandleFromPoolAsync<PlayerActionPacket>(data, client, _logger);
+                await HandleFromPoolAsync<PlayerActionPacket>(data, client);
                 break;
 
             case 0x1E:
-                await HandleFromPoolAsync<PlayerCommandPacket>(data, client, _logger);
+                await HandleFromPoolAsync<PlayerCommandPacket>(data, client);
                 break;
 
             case 0x22:
-                await HandleFromPoolAsync<SetSeenRecipePacket>(data, client, _logger);
+                await HandleFromPoolAsync<SetSeenRecipePacket>(data, client);
                 break;
 
             case 0x23:
-                await HandleFromPoolAsync<RenameItemPacket>(data, client, _logger);
+                await HandleFromPoolAsync<RenameItemPacket>(data, client);
                 break;
 
             case 0x2B:
-                await HandleFromPoolAsync<SetCreativeModeSlotPacket>(data, client, _logger);
+                await HandleFromPoolAsync<SetCreativeModeSlotPacket>(data, client);
                 break;
 
             case 0x2F:
-                await HandleFromPoolAsync<SwingArmPacket>(data, client, _logger);
+                await HandleFromPoolAsync<SwingArmPacket>(data, client);
                 break;
 
             case 0x31:
-                await HandleFromPoolAsync<UseItemOnPacket>(data, client, _logger);
+                await HandleFromPoolAsync<UseItemOnPacket>(data, client);
                 break;
             case 0x32:
-                await HandleFromPoolAsync<UseItemPacket>(data, client, _logger);
+                await HandleFromPoolAsync<UseItemPacket>(data, client);
                 break;
 
             default:
@@ -175,7 +175,7 @@ public class ClientHandler
         }
     }
 
-    private static async Task HandleFromPoolAsync<T>(byte[] data, Client client, ILogger logger) where T : IServerboundPacket, new()
+    private async Task HandleFromPoolAsync<T>(byte[] data, Client client) where T : IServerboundPacket, new()
     {
         var packet = ObjectPool<T>.Shared.Rent();
         try
@@ -186,7 +186,7 @@ public class ClientHandler
         catch (Exception e)
         {
             if (client.Server.Config.VerboseExceptionLogging)
-                logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
+                _logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
         }
         ObjectPool<T>.Shared.Return(packet);
     }

--- a/Obsidian/Utilities/ClientHandler.cs
+++ b/Obsidian/Utilities/ClientHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Logging;
 using Obsidian.Net.Packets;
 using Obsidian.Net.Packets.Play;
 using Obsidian.Net.Packets.Play.Clientbound;
@@ -11,10 +12,13 @@ public class ClientHandler
 {
     private ConcurrentDictionary<int, IServerboundPacket> Packets { get; } = new ConcurrentDictionary<int, IServerboundPacket>();
     private ServerConfiguration config;
+    private readonly ILogger _logger;
 
     public ClientHandler(ServerConfiguration config)
     {
         this.config = config;
+        var loggerProvider = new LoggerProvider(LogLevel.Error);
+        _logger = loggerProvider.CreateLogger("ClientHanlder");
     }
 
     public void RegisterHandlers()
@@ -73,84 +77,84 @@ public class ClientHandler
         switch (id)
         {
             case 0x00:
-                await HandleFromPoolAsync<ConfirmTeleportationPacket>(data, client);
+                await HandleFromPoolAsync<ConfirmTeleportationPacket>(data, client, _logger);
                 break;
             case 0x04:
-                await HandleFromPoolAsync<ChatCommandPacket>(data, client);
+                await HandleFromPoolAsync<ChatCommandPacket>(data, client, _logger);
                 break;
             case 0x05:
-                await HandleFromPoolAsync<ChatMessagePacket>(data, client);
+                await HandleFromPoolAsync<ChatMessagePacket>(data, client, _logger);
                 break;
             case 0x06:
-                await HandleFromPoolAsync<PlayerSessionPacket>(data, client);
+                await HandleFromPoolAsync<PlayerSessionPacket>(data, client, _logger);
                 break;
             case 0x07:
-                await HandleFromPoolAsync<ClientCommandPacket>(data, client);
+                await HandleFromPoolAsync<ClientCommandPacket>(data, client, _logger);
                 break;
             case 0x08:
-                await HandleFromPoolAsync<ClientInformationPacket>(data, client);
+                await HandleFromPoolAsync<ClientInformationPacket>(data, client, _logger);
                 break;
             case 0x0A:
-                await HandleFromPoolAsync<ClickContainerButtonPacket>(data, client);
+                await HandleFromPoolAsync<ClickContainerButtonPacket>(data, client, _logger);
                 break;
 
             case 0x0B:
-                await HandleFromPoolAsync<ClickContainerPacket>(data, client);
+                await HandleFromPoolAsync<ClickContainerPacket>(data, client, _logger);
                 break;
 
             case 0x0C:
-                await HandleFromPoolAsync<CloseContainerPacket>(data, client);
+                await HandleFromPoolAsync<CloseContainerPacket>(data, client, _logger);
                 break;
 
             case 0x0D:
-                await HandleFromPoolAsync<PluginMessagePacket>(data, client);
+                await HandleFromPoolAsync<PluginMessagePacket>(data, client, _logger);
                 break;
 
             case 0x10:
-                await HandleFromPoolAsync<InteractPacket>(data, client);
+                await HandleFromPoolAsync<InteractPacket>(data, client, _logger);
                 break;
 
             case 0x12:
-                await HandleFromPoolAsync<KeepAlivePacket>(data, client);
+                await HandleFromPoolAsync<KeepAlivePacket>(data, client, _logger);
                 break;
 
             case 0x1A:
-                await HandleFromPoolAsync<PickItemPacket>(data, client);
+                await HandleFromPoolAsync<PickItemPacket>(data, client, _logger);
                 break;
 
             case 0x1B:
-                await HandleFromPoolAsync<PlaceRecipePacket>(data, client);
+                await HandleFromPoolAsync<PlaceRecipePacket>(data, client, _logger);
                 break;
 
             case 0x1D:
-                await HandleFromPoolAsync<PlayerActionPacket>(data, client);
+                await HandleFromPoolAsync<PlayerActionPacket>(data, client, _logger);
                 break;
 
             case 0x1E:
-                await HandleFromPoolAsync<PlayerCommandPacket>(data, client);
+                await HandleFromPoolAsync<PlayerCommandPacket>(data, client, _logger);
                 break;
 
             case 0x22:
-                await HandleFromPoolAsync<SetSeenRecipePacket>(data, client);
+                await HandleFromPoolAsync<SetSeenRecipePacket>(data, client, _logger);
                 break;
 
             case 0x23:
-                await HandleFromPoolAsync<RenameItemPacket>(data, client);
+                await HandleFromPoolAsync<RenameItemPacket>(data, client, _logger);
                 break;
 
             case 0x2B:
-                await HandleFromPoolAsync<SetCreativeModeSlotPacket>(data, client);
+                await HandleFromPoolAsync<SetCreativeModeSlotPacket>(data, client, _logger);
                 break;
 
             case 0x2F:
-                await HandleFromPoolAsync<SwingArmPacket>(data, client);
+                await HandleFromPoolAsync<SwingArmPacket>(data, client, _logger);
                 break;
 
             case 0x31:
-                await HandleFromPoolAsync<UseItemOnPacket>(data, client);
+                await HandleFromPoolAsync<UseItemOnPacket>(data, client, _logger);
                 break;
             case 0x32:
-                await HandleFromPoolAsync<UseItemPacket>(data, client);
+                await HandleFromPoolAsync<UseItemPacket>(data, client, _logger);
                 break;
 
             default:
@@ -165,13 +169,13 @@ public class ClientHandler
                 catch (Exception e)
                 {
                     if (this.config.VerboseExceptionLogging)
-                        client.Logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
+                        _logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
                 }
                 break;
         }
     }
 
-    private static async Task HandleFromPoolAsync<T>(byte[] data, Client client) where T : IServerboundPacket, new()
+    private static async Task HandleFromPoolAsync<T>(byte[] data, Client client, ILogger logger) where T : IServerboundPacket, new()
     {
         var packet = ObjectPool<T>.Shared.Rent();
         try
@@ -182,7 +186,7 @@ public class ClientHandler
         catch (Exception e)
         {
             if (client.Server.Config.VerboseExceptionLogging)
-                client.Logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
+                logger.LogError(e.Message + Environment.NewLine + e.StackTrace);
         }
         ObjectPool<T>.Shared.Return(packet);
     }

--- a/Obsidian/Utilities/Converters/DefaultEnumConverter.cs
+++ b/Obsidian/Utilities/Converters/DefaultEnumConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Obsidian.API.Crafting;
+using Obsidian.API.Utilities;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/Obsidian/Utilities/Converters/IngredientConverter.cs
+++ b/Obsidian/Utilities/Converters/IngredientConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Obsidian.API.Crafting;
+using Obsidian.API.Utilities;
 using Obsidian.Registries;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/Obsidian/Utilities/Converters/RecipeConverter.cs
+++ b/Obsidian/Utilities/Converters/RecipeConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Obsidian.API.Crafting;
+using Obsidian.API.Utilities;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/Obsidian/Utilities/Extensions.Nbt.cs
+++ b/Obsidian/Utilities/Extensions.Nbt.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Obsidian.API.Registry.Codecs.Biomes;
+﻿using Obsidian.API.Registry.Codecs.Biomes;
 using Obsidian.API.Registry.Codecs.Chat;
 using Obsidian.API.Registry.Codecs.DamageTypes;
 using Obsidian.API.Registry.Codecs.Dimensions;
+using Obsidian.API.Utilities;
 using Obsidian.Nbt;
 using Obsidian.Registries;
 

--- a/Obsidian/Utilities/OperatorList.cs
+++ b/Obsidian/Utilities/OperatorList.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Logging;
 using System.Collections.Immutable;
 using System.IO;
 
@@ -9,6 +10,7 @@ public class OperatorList : IOperatorList
     private List<Operator> ops;
     private readonly List<OperatorRequest> reqs;
     private readonly Server server;
+    private readonly ILogger _logger;
     private string Path => System.IO.Path.Combine(System.IO.Path.Combine(this.server.ServerFolderPath, "config"), "ops.json");
 
     public OperatorList(Server server)
@@ -16,6 +18,8 @@ public class OperatorList : IOperatorList
         this.ops = new List<Operator>();
         this.reqs = new List<OperatorRequest>();
         this.server = server;
+        var loggerProvider = new LoggerProvider();
+        _logger = loggerProvider.CreateLogger("OperatorList");
     }
 
     public async Task InitializeAsync()
@@ -56,7 +60,7 @@ public class OperatorList : IOperatorList
             var req = new OperatorRequest(p);
             reqs.Add(req);
 
-            server.Logger.LogWarning($"New operator request from {p.Username}: {req.Code}");
+            _logger.LogWarning($"New operator request from {p.Username}: {req.Code}");
         }
 
         return result;

--- a/Obsidian/Utilities/ServerStatus.cs
+++ b/Obsidian/Utilities/ServerStatus.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Logging;
+using Obsidian.API.Utilities;
 using Obsidian.Entities;
 using System.IO;
 using System.Text.Json.Serialization;
@@ -7,6 +9,7 @@ namespace Obsidian.Utilities;
 
 public class ServerStatus : IServerStatus
 {
+    private readonly ILogger _logger;
     private static ReadOnlySpan<byte> PngHeader => new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
     private const string b64obsidian = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAOAklEQVR42q2baXMbNxKG+dXiMSeGM0NySFESReuwHTl27DiVo5LdzaZ2k0pqs7X//4/MotHTQOMait798JYtiRzifdBoAA1wkudtz5VljfdzltWW0nRc+J7Qc3y5nz+fl/10WkjBv6KfzQR7LddaqmPaDr9r1d+TpJLvTz3N54X1eZNzAaTpctBpCOYZIQAcKr4W3jed5gOAwgNgQ2gdAJ0GAK/7bAA+BNNYePNslusHnQKBjT5lHkXPNcoHANVI1HSe0pTMZ+cD8Huw0QDgjaEHzmaZ+luSLNUHp6lRllWR0DfRBA29uEiU7GdnCgAYGh82HECrngltCrUVBN6CANze4+NtsRDRBxIEUpJk8v25VCEbKyIQajXWyXgMwFyGfyiHhKKWXoM5JAYg894/oTfa5g0A7KX02QAWCwKQy+eSlrrx8LyQeRfAfFb0ouj6suxOQoBnQieBeO8LmRiv1k99K26U4HkutAmN85B5kD82bWVJ3S/LyyAAA6FSECiBhsyD2uq2L7O1EjR+tTwoAEWxjs4mFPKk6TRRbS7SVX+//7Z/f/dbv2sflQBCnq/CAPjYNL1fjRpvxHX/6c2f/duXP/e71aNl3AiSpdB5Ad4bMv/m9i/90+3f+4er73WD1/VtEADmGxT1uun5REVPXV4pABAB8KyuuevLYhOLgFaHe5KU8qHl0NjMGj9d89B/8+bflr59+o8CcLV50xeSbti8UM8dM//h4Y/+3ct/9q+uf9QAts29BLBRCpkncfOgMtv0j9c/6OeAQuadJLgcGpkF9XT82TP/6c2/+seb75V5EIQsDqVKGyfz83nuAWirgzZPAKjHsNcQAEQAzRohAItFpaMAIHXtQ3/TvT8PAPZ8ETR/vPxam/74+Ht/f/WN0mH7pTa/X78eIqB2IMBz7TxC5iF6SE/Hv1nmOQDs/TgAWCzNZqUCkWervsw31nM29ctgAtQAkkREAeTpWgGACHi4+k6Oq2+0aS74AHsqFXoozGZ+Dvnq8bdR8zoHyJ7j6wa/58WwbEYAOEOs+qW4lJBvRs0rAGQeFFpAZEmjGrNfYS+TuHlIMLb5ahj/YQBXmydt/uOr3/tD984zD2qqax3+LgDXvIGw1IudIl9HjTMA5SiAhZyzQ40DXa5eyX8fmHGa6goLQJriAgmU50v1XoiAL+9+CZqH0K/Ebhi3K2XeDfv53DdPUQB/d1d8RitLFgAcAu4iJ48C2MpZQchGGvOVGvNZButtUO5IqDxB7w+ZV8bLbhj7YfM47o3piwvcPMHv+GtCxnFKjQIILSMzOafu/YaWOxViZodI6/9yMF945qH3AQDMFqa37/T/l9q42SSFzFPvX1zkUpn6dzYrvNeFzI8CwGHAp8JwFIB5fACEGW16UHnOARQqGmA4IAAzNgFCMazKCikB012+VK/DPcRSKTTl2eZx5+i+Dhd0obD3AIgAgHLYjhoIFAVr1XBKLpUWAhAs/NF4kpBwcUUQ/I0MDJ2MSUSyfskA5KqdNO5J8D6MoPjY1wBwEYRjl8THFwHA8G3ZWroKCAEY0yjYLpMwR5BoCe6az9giqlLhbcTbVqjhwI2j+TgAdzPFVoIGAm4pucQQ3jD+KvUzKpc/Z2qhAyagQZCQQJBQQWD6xQsUJqtMvceYzQPms8G8GDZjZl1CCx5oFzfPARgIjQWBhhUoUhCp9Acbk0J9EIY3/z00aM6UDKu8TGdlAmIA0JjlRQ8OwkQhDsc8uDIFAG7YuwBsECHV8ZIY7tmFFiawUwAWzFQMQLhIgdtme+8QMx8a8yEIVL6DYTMGYRJfJQmm8gwAqQWAD4vQFIsAhN43QOLEvUPMPOYF33w1GM61eYw4FIDAadqGEAGwHIwXTKUzNPLgEMDfl/YQUktWApJZBUrbPBZUYjtSMIl7l1DvC+u13DwXtO8ZAGzzRQGyTaHJbDBuPhjMrpZ3Wre7j2rND4WT6827vimv+yxt2eqRAGDyc6PD2pjpZOZujISuBVB7YgBAJwA0AfMgPzm6vXy7+1pvcj7ItT4INjsEAKo9GwmlKQ99UxwkiDoAgBsxIBZzodcfBA/XBuXw2oUlWiH6AAo2TdbjAIx5AlCpMcgTpEqSskd37WtlmO/xCQIYv1q/VebX1UtlnmSiIAQg0eZbcVACCCbRlex1C0e5zj20aIL/wzRqziPULABr741TLPQjABIIJh9fUMAEcwTh1c0P/WFrV2Tg76C2vNXmi2zzDACpKrp29b16T53foPlZ4ZTWfAA8AZPwzMMskiZ4prYdIKzZVAiZczYoiZrP0kYDgN1hbOc4DoC20LBISq3EmsjeXxZXAfOLQbyszgEUuMEq9vL1y356UQ7mYTVIfjccQOccUsKi5kILihpBAMOyEnZZq+qojbowQgBCEHD+JwC4phDZTsk3TwBSXbojfXr9p8xJHwYI17KNe6nLQTutScg8mJpOZxYA+DnU+3xt7UKAsFVbXvkv/W4ljhYATIathgDzNV9DwJilpAcJj8LdKOtfH37qvzj8tX86/EMLABw2X+m6RZFfMQgMAB5e2ie1WBJfjAIIndIAAFFsJYRbCwKXmgUcAEvZsEybFBYAtQwf/sbHO/X+UU6zT0dp+taYV8ab1/LzHpTgMwtt3oS/GgL+2T/W2S8u4hEQuwNARYdaXKlDEw4BegEUGgaljEDoCLusxre1ONeHAMDzyPjD/kdlnD6XC3t/42nimjel60UkB5hdlpAhJBRRv+7GI4HyAUEAACRYExAAikZ/E1M5AEiZev5+9VYpZBxUFpesk1dxAHbt3owzPFaG7NkplTKz8h40EOxbHBAJOD0+qkoyFlEfdSSYBvoAzPF6xQCkclOVKMH/Z9MqaBjWGpCLYPrMA0Mcp3wGgMItfqZO5/CYOBpxo1dzMDXFAIBKOSSgynvdfaHlzgy5qi22wzBYsqFmAEBugMXMixepVghAka11zrCHkX0bBT6zKCQA/sLYmboJbZM9S5lQSIUC0EQFEDgAgoDmu2FubvXtDi4qtsJsgNvqXAsAwOpQ5RVYJWbrYE2AQ+BDFfLVxH2hdy6wKJ2y0tYCgWpOCIlvmqMyD4cp2/ZhMG96P7bYwvA3dQUSbMjAFOQb+/7SafO6IhR6A+2rQaFMbxZPW3aNJnYLzACg21yi3Ot8wgFg0TNn5a9iOP4uRgH4F7h8ANGTIX6nB15sGjwuDNtV5NITh0DJDYxumHHSRvd++DKGX1mi+mJoCg9p9GiMjrDw8KIavX/znNteNoTWAUAQbBCQZOMAsiAAOAPk9QFzkw1PiknqxHgMgH2CI4IRcL55DmAdEEUP/pwkpy5i4c7O9H7p3EM05mPnhSMATE0fS2Hmj6Fl73kAxsy3LPmduotkDwP4173eFzop5sqzdvyCBJ/H4YFQmDRX38RnQmgdrXp/71EPdf5477v7AzAL0KDN3DgWXn3zcNnyWQBwMwLGF17BE0FUZwIIQXjOLVFWNB2W3tApdDBK5pOkHoxneluMx2VoXMg1Csm9HRa8I4SboIuo8BqcYFWV+kwIftbG3odixlRtuKgKBOZjUystmmzzCasNlP2h+6jEaxKhCxMTPt5PASAIWM4+B0DjAaApCu8kTB3BLRKzZBb6NNqtWYQAZGrxtg1UpU5ckiIA86h5GA4zdj/4PABNcL6Gc0IXAJj/6uFXpRgEA6CwhgDkDEjqcNReFPVw5L6MtmvCH4jZNOvr6qp/c/hRbmKOfSl/D5o55k8BoJWkOsyAzVRmrt7bq865B+Dl/mP//u7X/nj5ob/ZPp2MAjopxkMP98SaAIQhBA9GAMDbu1+06Ioc3OmhOzyi3I6af/FirjSVvZMnCEBBSMcBwFb2fv9d//rmJ2WeAMAW2pzrt850TZciloPhyrm7YJ8HWgCyyPQAEO6vv/UuR3IIUGKCCqsb4mTeQJBhmXYykjpVR7QBJMNMM+vns1QB6Oo7bR7E6whFJJvblyDcmysnAMQggK43by0QX7/6g43L6wGCCW/oCRcAKE9WqvJDMw7u+4V1hW4uhxcAQAj3atfIAdgQVqO3v4xJ17w9LU/GzIPgwiF8MIC4239SjaLG1HIPTqVmghADQNtqU/AQwflfyIjiELh5frEqduXFvQliIrNhq1CjkxFAANyyFlycroYIQLW6sAlGfABCX2zA47UyuPhJ5CaHABCE0IELQFiK/QgAF4JrHpfmE7M+t0ODALTsSpv58Ie+rY7MvL3SMhcU6DsEpf5Cg/liQ/4sACBeWfau08q/l8U2AmBMGsCmPwUBEp4LoCgunZOWcHZ2jZNiX22Bg1A4PHEhcBDuZc1GfRFiPQKApnlS6wLYeC/mAJZyDnYhwLc77N4PZ+cYBAPAvxNQpOsgAD4s+FkDRsCaQeBf1zNrnMWCq1WV7olvvramCw5hvTwOdwWPLAJ2owAoMeK9nioCwFcrbkch0HkDzgodA+DXMWzjHEAHANz9efg2FWojp76rQOivTkIw3/GpvWgIAZjPylEAoOcA8HuezMP6ZWevBLGRyxMQut4+UT4PAP+GmukhEQQgip06YqvLS60QBLhW74d/EwQAW2joeTB/BoAli5BuWP1tVRJ5DoCx7w6T8FTY3AaDhhZFp8WXtgAGTpNIrnn38+BZJPSw+xwATQDA6tkATglyAkLI1ecY413gam7Nbn6HnmeX6s33GYwHGL4eAFNgDA8DfOBmMN/p5Pn/gmAva/lXYpvAveTVswEYCDS70eHo9lwAtVPSjgFY/Q/GV88AUDtffggDIAhYTjNDgBI66L9GX8+fJ1ZTswAAAABJRU5ErkJggg==";
 
@@ -27,6 +30,8 @@ public class ServerStatus : IServerStatus
     public ServerStatus(Server server, bool anonymous = false)
     {
         ArgumentNullException.ThrowIfNull(server);
+        var loggerProvider = new LoggerProvider();
+        _logger = loggerProvider.CreateLogger("ServerStatus");
 
         Version = ServerVersion.Of(server);
         if (!anonymous)
@@ -44,7 +49,7 @@ public class ServerStatus : IServerStatus
             }
             else
             {
-                server.Logger.LogError("The favicon.png is invalid! Skipping it.");
+                _logger.LogError("The favicon.png is invalid! Skipping it.");
                 Favicon = b64obsidian;
             }
         }

--- a/Obsidian/WorldData/Region.cs
+++ b/Obsidian/WorldData/Region.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.Utilities;
 using Obsidian.Blocks;
 using Obsidian.ChunkData;
 using Obsidian.Entities;

--- a/Obsidian/WorldData/WorldManager.cs
+++ b/Obsidian/WorldData/WorldManager.cs
@@ -50,7 +50,7 @@ public sealed class WorldManager : IAsyncDisposable
                 {
                     if (!CodecRegistry.TryGetDimension(dimensionName, out var codec))
                     {
-                        this.server.Logger.LogWarning($"Failed to find dimension with the name {dimensionName}");
+                        logger.LogWarning($"Failed to find dimension with the name {dimensionName}");
                         continue;
                     }
 


### PR DESCRIPTION
* Move logging into the API library
* Give classes their own loggers instead of excessive passing of Server's logger

Happy loggers correctly identifying themselves now:
![image](https://github.com/ObsidianMC/Obsidian/assets/1430182/01392475-3a86-4a26-a616-2fa36c56dd73)
