### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/Obsidian/Blocks/BlockMeta.cs
+++ b/Obsidian/Blocks/BlockMeta.cs
@@ -9,7 +9,7 @@ public struct BlockMeta
 
     public IReadOnlyList<string> CanPlaceOn { get; internal set; }
 
-    // https://minecraft.gamepedia.com/Chunk_format#Block_entity_format
+    // https://minecraft.wiki/w/Chunk_format#Block_entity_format
     public NbtCompound BlockEntityTag { get; internal set; }
     public NbtCompound BlockStateTag { get; internal set; }
 }

--- a/Obsidian/Net/Packets/Play/Clientbound/SpawnExperienceOrbPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/SpawnExperienceOrbPacket.cs
@@ -5,7 +5,7 @@ namespace Obsidian.Net.Packets.Play.Clientbound;
 public partial class SpawnExperienceOrbPacket : IClientboundPacket
 {
     [Field(0), VarLength]
-    private const int EntityId = 2; // Source: https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening/Entity_IDs
+    private const int EntityId = 2; // Source: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening/Entity_IDs
 
     [Field(1), DataFormat(typeof(double))]
     public VectorF Position { get; }

--- a/Obsidian/WorldData/Level.cs
+++ b/Obsidian/WorldData/Level.cs
@@ -3,7 +3,7 @@ using Obsidian.Nbt;
 namespace Obsidian.WorldData;
 
 /// <summary>
-/// https://minecraft.gamepedia.com/Java_Edition_level_format
+/// https://minecraft.wiki/w/Java_Edition_level_format
 /// </summary>
 public sealed class Level
 {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.