### PR TITLE
Improve BlockStateBuilders

### DIFF
--- a/Obsidian.API/Utilities/Extensions.cs
+++ b/Obsidian.API/Utilities/Extensions.cs
@@ -1,17 +1,17 @@
 ﻿using System.Diagnostics;
+using System.Transactions;
 
 namespace Obsidian.API.Utilities;
 public static partial class Extensions
 {
-    public static List<string> GetStateValues(this string key, Dictionary<string, string[]> valueStores)
+    public static List<string> GetStateValues(this int[] indexes, Dictionary<string, string[]> valueStores)
     {
         var list = new List<string>();
-        var vals = key.Split("-");
 
         var count = 0;
         foreach (var (_, values) in valueStores)
         {
-            var index = int.Parse(vals[count++]);
+            var index = indexes[count++];
 
             var value = values[index];
 
@@ -21,7 +21,20 @@ public static partial class Extensions
         return list;
     }
 
-    public static string GetIndexFromArray(this string[] array, string value)
+    public static int GetIndexFromJaggedArray(this int[][] array, int[] value)
+    {
+        for(int i = 0; i < array.Length; i++)
+        {
+            var child = array[i];
+
+            if (Enumerable.SequenceEqual(child, value))
+                return i;
+        }
+
+        return -1;
+    }
+
+    public static int GetIndexFromArray(this string[] array, string value)
     {
         var propertyValue = bool.TryParse(value, out _) ? value.ToLower() : value;
 
@@ -31,7 +44,7 @@ public static partial class Extensions
         for(int i = 0; i < array.Length; i++)
         {
             if (array[i] == propertyValue)
-                return $"{i}";
+                return i;
         }
 
         throw new UnreachableException();

--- a/Obsidian.SourceGenerators/Registry/BlocksGenerator.BlockStateBuilder.cs
+++ b/Obsidian.SourceGenerators/Registry/BlocksGenerator.BlockStateBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Obsidian.SourceGenerators.Registry.Models;
+using System.Reflection;
 
 namespace Obsidian.SourceGenerators.Registry;
 public partial class BlocksGenerator
@@ -20,17 +21,19 @@ public partial class BlocksGenerator
 
     private static void GeneratePossibleStates(CodeBuilder stateBuilder, Dictionary<int, List<string>> stateValues, BlockProperty[] properties)
     {
-        stateBuilder.Statement("private Dictionary<string, int> possibleStates = new()");
+        stateBuilder.Indent().Append("private int[] stateIds = [");
+        foreach (var key in stateValues.Keys)
+            stateBuilder.Append($"{key},");
 
-        var list = new List<string>();
-        foreach (var kv in stateValues)
+        stateBuilder.Append("];").Line();
+
+        stateBuilder.Indent().Append("private int[][] stateIndexes = [");
+
+        foreach (var values in stateValues.Values)
         {
-            var key = kv.Key;
-            var values = kv.Value;
-
-            list.Clear();
-
             var count = 0;
+
+            stateBuilder.Append("[");
             foreach (var value in values)
             {
                 var property = properties[count++];
@@ -42,16 +45,15 @@ public partial class BlocksGenerator
 
                 var index = GetPropertyIndex(property.Values, value);
 
-                list.Add(index);
+                stateBuilder.Append($"{index},");
             }
-
-            stateBuilder.Indent().Append("{ ").Append($"\"{string.Join("-", list)}\", {key}").Append(" },").Line();
+            stateBuilder.Append("],");
         }
 
-        stateBuilder.EndScope(true);
+        stateBuilder.Append("];").Line();
     }
 
-    private static string GetPropertyIndex(string[] array, string value)
+    private static int GetPropertyIndex(string[] array, string value)
     {
         var propertyValue = bool.TryParse(value, out _) ? value.ToLower() : value;
 
@@ -61,7 +63,7 @@ public partial class BlocksGenerator
         for (int i = 0; i < array.Length; i++)
         {
             if (array[i] == propertyValue)
-                return $"{i}";
+                return i;
         }
 
         throw new InvalidOperationException();
@@ -71,9 +73,10 @@ public partial class BlocksGenerator
     {
         stateBuilder.Line().Line().Method($"public {fullName}(int currentStateId)");
 
-        stateBuilder.Line("var (key, _) = this.possibleStates.First(x => x.Value == currentStateId);");
+        stateBuilder.Line("var arrayIndex = Array.IndexOf(stateIds, currentStateId);");
+        stateBuilder.Line("var stateIndexes = this.stateIndexes[arrayIndex];");
 
-        stateBuilder.Line("var values = key.GetStateValues(this.valueStore);");
+        stateBuilder.Line("var values = stateIndexes.GetStateValues(this.valueStore);");
 
         var count = 0;
         foreach (var property in properties)
@@ -199,7 +202,7 @@ public partial class BlocksGenerator
             }
         }
 
-        stateBuilder.Statement("var list = new List<string>()");
+        stateBuilder.Line().Line("int[] rawValue = [");
 
         foreach (var property in properties)
         {
@@ -209,8 +212,10 @@ public partial class BlocksGenerator
             stateBuilder.Line($"this.valueStore[\"{name}\"].GetIndexFromArray(this.{sanitizedName}.ToString()),");
         }
 
-        stateBuilder.EndScope(true).Line();
+        stateBuilder.Line("];");
 
-        stateBuilder.Line().Line($"var stateId = this.possibleStates[string.Join(\"-\", list)];");
+        stateBuilder.Line().Line($"var stateIndex = this.stateIndexes.GetIndexFromJaggedArray(rawValue);");
+
+        stateBuilder.Line().Line($"var stateId = this.stateIds[stateIndex];");
     }
 }

--- a/Obsidian.SourceGenerators/Registry/BlocksGenerator.BlockStateBuilder.cs
+++ b/Obsidian.SourceGenerators/Registry/BlocksGenerator.BlockStateBuilder.cs
@@ -21,13 +21,13 @@ public partial class BlocksGenerator
 
     private static void GeneratePossibleStates(CodeBuilder stateBuilder, Dictionary<int, List<string>> stateValues, BlockProperty[] properties)
     {
-        stateBuilder.Indent().Append("private int[] stateIds = [");
+        stateBuilder.Indent().Append("private static ReadOnlySpan<int> StateIds => [");
         foreach (var key in stateValues.Keys)
             stateBuilder.Append($"{key},");
 
         stateBuilder.Append("];").Line();
 
-        stateBuilder.Indent().Append("private int[][] stateIndexes = [");
+        stateBuilder.Indent().Append("private static int[][] StatePropertyIndexes => [");
 
         foreach (var values in stateValues.Values)
         {
@@ -73,10 +73,10 @@ public partial class BlocksGenerator
     {
         stateBuilder.Line().Line().Method($"public {fullName}(int currentStateId)");
 
-        stateBuilder.Line("var arrayIndex = Array.IndexOf(stateIds, currentStateId);");
-        stateBuilder.Line("var stateIndexes = this.stateIndexes[arrayIndex];");
+        stateBuilder.Line("var arrayIndex = StateIds.IndexOf(currentStateId);");
+        stateBuilder.Line("var stateIndexesResult = StatePropertyIndexes[arrayIndex];");
 
-        stateBuilder.Line("var values = stateIndexes.GetStateValues(this.valueStore);");
+        stateBuilder.Line("var values = stateIndexesResult.GetStateValues(this.valueStore);");
 
         var count = 0;
         foreach (var property in properties)
@@ -214,8 +214,8 @@ public partial class BlocksGenerator
 
         stateBuilder.Line("];");
 
-        stateBuilder.Line().Line($"var stateIndex = this.stateIndexes.GetIndexFromJaggedArray(rawValue);");
+        stateBuilder.Line().Line($"var stateIndex = StatePropertyIndexes.GetIndexFromJaggedArray(rawValue);");
 
-        stateBuilder.Line().Line($"var stateId = this.stateIds[stateIndex];");
+        stateBuilder.Line().Line($"var stateId = StateIds[stateIndex];");
     }
 }


### PR DESCRIPTION
Instead of using strings to track the indexes of state properties, I opted to use a jagged array and a normal array to track state ids and state property indexes.

What pushed me to do this was this:

![image](https://github.com/ObsidianMC/Obsidian/assets/20138497/c47e9865-d1e7-4952-877d-e97c489ca88f)

😅 

[New State Builder](https://gist.github.com/Tides/c2c36b7da42145fb6732b66ddcfc9a16)
[Old State Builder](https://gist.github.com/Tides/3e7e016efc017276fdff36b9bb0cc340)
