### PR TITLE
Fix commands not finding valid executor 

### DIFF
--- a/Obsidian/Commands/Framework/Entities/Command.cs
+++ b/Obsidian/Commands/Framework/Entities/Command.cs
@@ -109,7 +109,10 @@ public sealed class Command
                 var arg = args[i];
 
                 if (!CommandHandler.IsValidArgumentType(param.ParameterType))
-                    return false;
+                {
+                    success = false;
+                    continue;
+                }
 
                 var parser = CommandHandler.GetArgumentParser(param.ParameterType);
                 if (parser.TryParseArgument(arg, context, out _))
@@ -118,7 +121,7 @@ public sealed class Command
                     continue;
                 }
 
-                return false;
+                success = false;
             }
 
             if (success)

--- a/Obsidian/Commands/Framework/Entities/Command.cs
+++ b/Obsidian/Commands/Framework/Entities/Command.cs
@@ -88,7 +88,7 @@ public sealed class Command
     }
 
     private bool TryFindExecutor(IEnumerable<IExecutor<CommandContext>> executors, string[] args, CommandContext context,
-        [NotNullWhen(true)]out IExecutor<CommandContext>? executor)
+        [NotNullWhen(true)] out IExecutor<CommandContext>? executor)
     {
         executor = null;
 
@@ -102,8 +102,6 @@ public sealed class Command
 
         foreach (var exec in executors)
         {
-            executor = exec;
-
             var methodParams = exec.GetParameters();
             for (int i = 0; i < args.Length; i++)
             {
@@ -111,11 +109,7 @@ public sealed class Command
                 var arg = args[i];
 
                 if (!CommandHandler.IsValidArgumentType(param.ParameterType))
-                {
-                    success = false;
-                    executor = null;
                     return false;
-                }
 
                 var parser = CommandHandler.GetArgumentParser(param.ParameterType);
                 if (parser.TryParseArgument(arg, context, out _))
@@ -124,12 +118,14 @@ public sealed class Command
                     continue;
                 }
 
-                success = false;
                 return false;
             }
 
             if (success)
+            {
+                executor = exec;
                 return true;
+            }
         }
 
         return false;

--- a/Obsidian/Commands/Framework/Entities/Command.cs
+++ b/Obsidian/Commands/Framework/Entities/Command.cs
@@ -87,6 +87,9 @@ public sealed class Command
         {
             executor = exec;
 
+            if(args.Length == 0)
+                success = true;//First executor will work
+
             var methodParams = exec.GetParameters();
             for (int i = 0; i < args.Length; i++)
             {


### PR DESCRIPTION
Fixes No valid executor was found due to there being no arguments. This makes sure to use first executor if there are no arguments