### PR TITLE
Expose MinecraftStream

### DIFF
--- a/Obsidian.API/_Interfaces/INetSteamReader.cs
+++ b/Obsidian.API/_Interfaces/INetSteamReader.cs
@@ -1,6 +1,8 @@
 ﻿namespace Obsidian.API;
-public interface INetSteamReader
+public interface INetSteamReader : INetStream
 {
+    public bool CanRead { get; }
+
     public sbyte ReadSignedByte();
     public byte ReadUnsignedByte();
     public bool ReadBoolean();

--- a/Obsidian.API/_Interfaces/INetSteamReader.cs
+++ b/Obsidian.API/_Interfaces/INetSteamReader.cs
@@ -29,7 +29,7 @@ public interface INetSteamReader : INetStream
     public SoundPosition ReadSoundPosition();
 
     public Angle ReadAngle();
-    public Angle ReadFloatAngle() => ReadFloat();
+    public Angle ReadFloatAngle();
     public ChatMessage ReadChat();
     public byte[] ReadByteArray();
     public Guid ReadGuid();

--- a/Obsidian.API/_Interfaces/INetSteamReader.cs
+++ b/Obsidian.API/_Interfaces/INetSteamReader.cs
@@ -1,0 +1,37 @@
+﻿namespace Obsidian.API;
+public interface INetSteamReader
+{
+    public sbyte ReadSignedByte();
+    public byte ReadUnsignedByte();
+    public bool ReadBoolean();
+    public ushort ReadUnsignedShort();
+    public short ReadShort();
+    public int ReadInt();
+    public long ReadLong();
+    public ulong ReadUnsignedLong();
+    public float ReadFloat();
+    public double ReadDouble();
+    public string ReadString(int maxLength = short.MaxValue);
+    public int ReadVarInt();
+    public byte[] ReadUInt8Array(int length = 0);
+    public long ReadVarLong();
+
+    public DateTimeOffset ReadDateTimeOffset();
+
+    public Vector ReadPosition();
+    public Vector ReadAbsolutePosition();
+    public VectorF ReadPositionF();
+    public VectorF ReadAbsolutePositionF();
+    public VectorF ReadAbsoluteFloatPositionF();
+
+    public SoundPosition ReadSoundPosition();
+
+    public Angle ReadAngle();
+    public Angle ReadFloatAngle() => ReadFloat();
+    public ChatMessage ReadChat();
+    public byte[] ReadByteArray();
+    public Guid ReadGuid();
+    public Guid? ReadOptionalGuid();
+    public ItemStack ReadItemStack();
+    public Velocity ReadVelocity();
+}

--- a/Obsidian.API/_Interfaces/INetStream.cs
+++ b/Obsidian.API/_Interfaces/INetStream.cs
@@ -1,0 +1,7 @@
+﻿namespace Obsidian.API;
+public interface INetStream : IDisposable, IAsyncDisposable
+{
+    public long Length { get; }
+
+    public long Position { get; set; }
+}

--- a/Obsidian.API/_Interfaces/INetStreamReader.cs
+++ b/Obsidian.API/_Interfaces/INetStreamReader.cs
@@ -1,5 +1,5 @@
 ﻿namespace Obsidian.API;
-public interface INetSteamReader : INetStream
+public interface INetStreamReader : INetStream
 {
     public bool CanRead { get; }
 

--- a/Obsidian.API/_Interfaces/INetStreamWriter.cs
+++ b/Obsidian.API/_Interfaces/INetStreamWriter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Obsidian.API;
-public interface INetStreamWriter
+public interface INetStreamWriter : INetStream
 {
+    public bool CanWrite { get; }
     public void WriteByte(sbyte value);
     public void WriteUnsignedByte(byte value);
     public void WriteBoolean(bool value);
@@ -29,4 +30,6 @@ public interface INetStreamWriter
     public void WriteSoundEffect(SoundEffect sound);
     public void WriteByteArray(byte[] values);
     public void WriteUuid(Guid value);
+
+    public byte[] ToArray();
 }

--- a/Obsidian.API/_Interfaces/INetStreamWriter.cs
+++ b/Obsidian.API/_Interfaces/INetStreamWriter.cs
@@ -1,0 +1,32 @@
+﻿namespace Obsidian.API;
+public interface INetStreamWriter
+{
+    public void WriteByte(sbyte value);
+    public void WriteUnsignedByte(byte value);
+    public void WriteBoolean(bool value);
+
+    public void WriteUnsignedShort(ushort value);
+    public void WriteShort(short value);
+
+    public void WriteInt(int value);
+
+    public void WriteLong(long value);
+
+    public void WriteFloat(float value);
+    public void WriteDouble(double value);
+
+    public void WriteString(string value, int maxLength = short.MaxValue);
+    public void WriteVarInt(int value);
+    public void WriteVarInt(Enum value);
+
+    public void WriteLongArray(long[] values);
+    public void WriteVarLong(long value);
+
+    public void WriteBitSet(BitSet bitset, bool isFixed = false);
+    public void WriteChat(ChatMessage chatMessage);
+    public void WriteItemStack(ItemStack itemStack);
+    public void WriteDateTimeOffset(DateTimeOffset date);
+    public void WriteSoundEffect(SoundEffect sound);
+    public void WriteByteArray(byte[] values);
+    public void WriteUuid(Guid value);
+}

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Obsidian.Net;
 
-public partial class MinecraftStream
+public partial class MinecraftStream : INetSteamReader
 {
 
     [ReadMethod]

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Obsidian.Net;
 
-public partial class MinecraftStream : INetSteamReader
+public partial class MinecraftStream : INetStreamReader
 {
 
     [ReadMethod]

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -1,5 +1,4 @@
-﻿using Obsidian.API;
-using Obsidian.API.Advancements;
+﻿using Obsidian.API.Advancements;
 using Obsidian.API.Crafting;
 using Obsidian.API.Inventory;
 using Obsidian.API.Registry.Codecs.ArmorTrims.TrimMaterial;
@@ -26,7 +25,7 @@ using System.Text.Json;
 
 namespace Obsidian.Net;
 
-public partial class MinecraftStream
+public partial class MinecraftStream : INetStreamWriter
 {
     [WriteMethod]
     public void WriteByte(sbyte value)


### PR DESCRIPTION
As the title states, this is to give developers a way to write/read packet data. An example would be through plugin messages or the new ItemComponents introduced in 1.21. 