### PR TITLE
Fix source generator warnings

### DIFF
--- a/Obsidian.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/Obsidian.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,3 @@
+﻿; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+

--- a/Obsidian.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Obsidian.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,10 @@
+﻿; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DBG001 | SerializationMethodGeneration | Warning | DiagnosticDescriptors
+DBG002 | SerializationMethodGeneration | Warning | DiagnosticDescriptors
+DBG003 | SerializationMethodGeneration | Warning | DiagnosticDescriptors

--- a/Obsidian.SourceGenerators/Extensions.CodeBuilder.cs
+++ b/Obsidian.SourceGenerators/Extensions.CodeBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Obsidian.SourceGenerators.Registry;
 using Obsidian.SourceGenerators.Registry.Models;
+using System.Globalization;
 using System.Text.Json;
 
 namespace Obsidian.SourceGenerators;
@@ -102,9 +103,9 @@ public partial class Extensions
                         else if (element.TryGetInt64(out var longValue))
                             builder.Append($"{longValue} }},");
                         else if (element.TryGetSingle(out var floatValue))
-                            builder.Append($"{floatValue}f }},");
+                            builder.Append($"{floatValue.ToString(CultureInfo.InvariantCulture)}f }},");
                         else if (element.TryGetDouble(out var doubleValue))
-                            builder.Append($"{doubleValue}d }},");
+                            builder.Append($"{doubleValue.ToString(CultureInfo.InvariantCulture)}d }},");
                         break;
                     }
                 case JsonValueKind.True:
@@ -133,9 +134,9 @@ public partial class Extensions
                     else if (element.TryGetInt64(out var longValue))
                         builder.Append($"{longValue}, ");
                     else if (element.TryGetSingle(out var floatValue))
-                        builder.Append($"{floatValue}f, ");
+                        builder.Append($"{floatValue.ToString(CultureInfo.InvariantCulture)}f, ");
                     else if (element.TryGetDouble(out var doubleValue))
-                        builder.Append($"{doubleValue}d, ");
+                        builder.Append($"{doubleValue.ToString(CultureInfo.InvariantCulture)}d, ");
                     break;
                 }
             case JsonValueKind.True:

--- a/Obsidian.SourceGenerators/Extensions.cs
+++ b/Obsidian.SourceGenerators/Extensions.cs
@@ -15,4 +15,10 @@ public static partial class Extensions
 
         return tag.Parent == tag.Type ? tag.Name : $"{tag.Type.ToPascalCase()}.{tag.Name}";
     }
+
+    public static void Deconstruct<TKey, TValue>(this IGrouping<TKey, TValue> grouping, out TKey key, out List<TValue> values)
+    {
+        key = grouping.Key;
+        values = grouping.ToList();
+    }
 }

--- a/Obsidian.SourceGenerators/Obsidian.SourceGenerators.csproj
+++ b/Obsidian.SourceGenerators/Obsidian.SourceGenerators.csproj
@@ -7,6 +7,7 @@
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
 		<IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Obsidian.SourceGenerators/Packets/AttributeOwner.cs
+++ b/Obsidian.SourceGenerators/Packets/AttributeOwner.cs
@@ -2,12 +2,12 @@
 
 namespace Obsidian.SourceGenerators.Packets;
 
-internal abstract class AttributeOwner
+internal abstract class AttributeOwner(AttributeFlags flags, AttributeBehaviorBase[] attributes)
 {
-    public AttributeFlags Flags { get; set; }
-    public AttributeBehaviorBase[] Attributes { get; set; }
+    public AttributeFlags Flags { get; } = flags;
+    public AttributeBehaviorBase[] Attributes { get; } = attributes;
 
-    public bool TryGetAttribute<TAttribute>(out TAttribute attribute) where TAttribute : AttributeBehaviorBase
+    public bool TryGetAttribute<TAttribute>(out TAttribute? attribute) where TAttribute : AttributeBehaviorBase
     {
         for (int i = 0; i < Attributes.Length; i++)
         {
@@ -20,5 +20,21 @@ internal abstract class AttributeOwner
 
         attribute = default;
         return false;
+    }
+
+    protected static AttributeFlags AggregateFlags(AttributeBehaviorBase[] attributes)
+    {
+        var flags = AttributeFlags.None;
+        foreach (AttributeBehaviorBase attribute in attributes)
+        {
+            flags |= attribute.Flag;
+        }
+        return flags;
+    }
+
+    protected static string GetRelativeTypeName(string typeName)
+    {
+        int dotIndex = typeName.LastIndexOf('.');
+        return dotIndex >= 0 ? typeName.Substring(dotIndex + 1) : typeName;
     }
 }

--- a/Obsidian.SourceGenerators/Packets/Attributes/AttributeBehaviorBase.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/AttributeBehaviorBase.cs
@@ -3,19 +3,13 @@ using System.Text;
 
 namespace Obsidian.SourceGenerators.Packets.Attributes;
 
-internal abstract class AttributeBehaviorBase
+internal abstract class AttributeBehaviorBase(AttributeSyntax attributeSyntax)
 {
     public abstract string Name { get; }
     public abstract AttributeFlags Flag { get; }
 
-    protected readonly AttributeSyntax syntax;
-    private readonly AttributeArgumentSyntax[] arguments;
-
-    public AttributeBehaviorBase(AttributeSyntax attributeSyntax)
-    {
-        syntax = attributeSyntax;
-        arguments = attributeSyntax?.ArgumentList?.Arguments.Select(arg => arg).ToArray() ?? [];
-    }
+    protected readonly AttributeSyntax syntax = attributeSyntax;
+    private readonly AttributeArgumentSyntax[] arguments = attributeSyntax?.ArgumentList?.Arguments.Select(arg => arg).ToArray() ?? [];
 
     public virtual bool Matches(AttributeOwner other)
     {
@@ -60,7 +54,7 @@ internal abstract class AttributeBehaviorBase
             }
         }
 
-        syntax = null;
+        syntax = null!;
         return false;
     }
 
@@ -79,10 +73,11 @@ internal abstract class AttributeBehaviorBase
 
     protected bool TryEvaluateTypeArgument(out string argument)
     {
-        argument = null;
-
         if (!TryGetArgument(out TypeSyntax expression))
+        {
+            argument = null!;
             return false;
+        }
 
         argument = expression.GetText().ToString();
         return true;
@@ -90,10 +85,11 @@ internal abstract class AttributeBehaviorBase
 
     protected bool TryEvaluateStringArgument(out string argument)
     {
-        argument = null;
-
         if (!TryGetArgument(out ExpressionSyntax expression))
+        {
+            argument = null!;
             return false;
+        }
 
         return TryEvaluateString(expression, out argument);
     }
@@ -112,13 +108,13 @@ internal abstract class AttributeBehaviorBase
 
             // "A" + "B"
             BinaryExpressionSyntax binaryAdd when binaryAdd.Kind() == SyntaxKind.AddExpression
-                => TryEvaluateString(binaryAdd.Left, out var left) && TryEvaluateString(binaryAdd.Right, out var right) ? left + right : null,
+                => TryEvaluateString(binaryAdd.Left, out var left) && TryEvaluateString(binaryAdd.Right, out var right) ? left + right : null!,
 
             // $"A {B} C"
             InterpolatedStringExpressionSyntax interpolation
-                => TryEvaluateInterpolatedString(interpolation, out var interpolatedText) ? interpolatedText : null,
+                => TryEvaluateInterpolatedString(interpolation, out var interpolatedText) ? interpolatedText : null!,
 
-            _ => null
+            _ => null!
         };
 
         return result is not null;
@@ -142,7 +138,7 @@ internal abstract class AttributeBehaviorBase
             }
             else
             {
-                result = null;
+                result = null!;
                 return false;
             }
         }

--- a/Obsidian.SourceGenerators/Packets/Attributes/AttributeFactory.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/AttributeFactory.cs
@@ -15,7 +15,7 @@ internal static class AttributeFactory
         if (attributeName.EndsWith("Attribute"))
             attributeName = attributeName.Substring(0, attributeName.Length - 9);
 
-        attributeBehaviorBase = methods.TryGetValue(attributeName, out FactoryMethod factoryMethod) ? factoryMethod(attribute) : null;
+        attributeBehaviorBase = methods.TryGetValue(attributeName, out FactoryMethod factoryMethod) ? factoryMethod(attribute) : null!;
 
         return attributeBehaviorBase is not null;
     }

--- a/Obsidian.SourceGenerators/Packets/Attributes/ConditionBehavior.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/ConditionBehavior.cs
@@ -69,12 +69,12 @@ internal sealed class ConditionBehavior : AttributeBehaviorBase
     {
         var sharedCondition = context.AllProperties
             .SkipWhile(prop => prop != context.Property)
-            .Select(prop => new { Property = prop, Attribute = prop.TryGetAttribute(out ConditionBehavior condition) ? condition : null })
+            .Select(prop => new { Property = prop, Attribute = prop.TryGetAttribute(out ConditionBehavior? condition) ? condition : null })
             .TakeWhile(entry => entry.Attribute?.Condition == Condition);
 
         foreach (var shared in sharedCondition.Skip(1))
         {
-            shared.Attribute.Skip = true;
+            shared.Attribute!.Skip = true;
         }
 
         return sharedCondition.Last().Property;

--- a/Obsidian.SourceGenerators/Packets/Attributes/CountTypeBehavior.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/CountTypeBehavior.cs
@@ -35,7 +35,7 @@ internal sealed class CountTypeBehavior : AttributeBehaviorBase
         }
 
         string getLength = $"{context.StreamName}.{readMethod}()";
-        context.CodeBuilder.Line($"{context.DataName} = {context.Property.NewCollection(getLength)};");
+        context.CodeBuilder.Line($"{context.DataName} = {context.Property.GetNewCollectionExpression(getLength)};");
         return true;
     }
 }

--- a/Obsidian.SourceGenerators/Packets/Attributes/DataFormatBehavior.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/DataFormatBehavior.cs
@@ -17,7 +17,7 @@ internal sealed class DataFormatBehavior : AttributeBehaviorBase
     public override bool Matches(AttributeOwner other)
     {
         return other.Flags.HasFlag(Flag) &&
-            other.TryGetAttribute(out DataFormatBehavior format) &&
-            format.Type == Type;
+            other.TryGetAttribute(out DataFormatBehavior? format) &&
+            format!.Type == Type;
     }
 }

--- a/Obsidian.SourceGenerators/Packets/Attributes/FixedLengthBehavior.cs
+++ b/Obsidian.SourceGenerators/Packets/Attributes/FixedLengthBehavior.cs
@@ -34,7 +34,7 @@ internal sealed class FixedLengthBehavior : AttributeBehaviorBase
             return false;
         }
 
-        context.CodeBuilder.Line($"{context.DataName} = {context.Property.NewCollection(Length.ToString())}");
+        context.CodeBuilder.Line($"{context.DataName} = {context.Property.GetNewCollectionExpression(Length.ToString())}");
         return true;
     }
 }

--- a/Obsidian.SourceGenerators/Packets/Method.cs
+++ b/Obsidian.SourceGenerators/Packets/Method.cs
@@ -2,28 +2,11 @@
 
 namespace Obsidian.SourceGenerators.Packets;
 
-internal sealed class Method : AttributeOwner
+internal sealed class Method(string name, string type, AttributeBehaviorBase[] attributes)
+    : AttributeOwner(AggregateFlags(attributes) | AttributeFlags.Field, attributes)
 {
-    public string Name { get; }
-    public string Type { get; }
-
-    public Method(string name, string type, AttributeBehaviorBase[] attributes)
-    {
-        Name = name;
-        Type = type;
-        Attributes = attributes;
-
-        if (Type.Contains('.'))
-        {
-            Type = Type.Substring(Type.LastIndexOf('.') + 1);
-        }
-
-        Flags = AttributeFlags.Field;
-        for (int i = 0; i < attributes.Length; i++)
-        {
-            Flags |= attributes[i].Flag;
-        }
-    }
+    public string Name { get; } = name;
+    public string Type { get; } = GetRelativeTypeName(type);
 
     public override string ToString()
     {

--- a/Obsidian.SourceGenerators/Packets/MethodsRegistry.cs
+++ b/Obsidian.SourceGenerators/Packets/MethodsRegistry.cs
@@ -32,7 +32,7 @@ internal sealed class MethodsRegistry
 
     private bool TryGetMethod(IEnumerable<Method> source, Property property, bool collection, out Method outMethod)
     {
-        string propertyType = collection ? property.CollectionType : property.Type;
+        string? propertyType = collection ? property.CollectionType : property.Type;
         foreach (Method method in source)
         {
             if (method.Type != propertyType)
@@ -48,7 +48,7 @@ internal sealed class MethodsRegistry
             return true;
         }
 
-        outMethod = null;
+        outMethod = null!;
         return false;
     }
 
@@ -90,7 +90,7 @@ internal sealed class MethodsRegistry
 
     private bool TryGetWriteMethodType(GeneratorExecutionContext context, MethodDeclarationSyntax method, out string type)
     {
-        type = null;
+        type = null!;
 
         var parameters = method.ParameterList.Parameters;
         if (parameters.Count == 0)
@@ -111,7 +111,7 @@ internal sealed class MethodsRegistry
             return false;
         }
 
-        type = parameter.Type.ToString();
+        type = parameter.Type!.ToString();
         return true;
     }
 

--- a/Obsidian.SourceGenerators/Registry/EntityGenerator.cs
+++ b/Obsidian.SourceGenerators/Registry/EntityGenerator.cs
@@ -2,6 +2,7 @@
 using Obsidian.SourceGenerators.Registry.Models;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Xml.Schema;
@@ -120,8 +121,8 @@ public sealed partial class EntityGenerator : IIncrementalGenerator
                 .Type($"public partial class {@class.Symbol.Name}");
 
             builder.Indent().Append("public override EntityDimension Dimension { get; protected set; } = new() { ")
-                .Append($"Width = {widthElement.GetSingle()}f, ")
-                .Append($"Height = {heightElement.GetSingle()}f }}; ")
+                .Append($"Width = {widthElement.GetSingle().ToString(CultureInfo.InvariantCulture)}f, ")
+                .Append($"Height = {heightElement.GetSingle().ToString(CultureInfo.InvariantCulture)}f }}; ")
                 .Line()
                 .Line();
 
@@ -153,7 +154,7 @@ public sealed partial class EntityGenerator : IIncrementalGenerator
                 foreach (var attrElement in attributesElement.EnumerateObject())
                 {
                     var name = attrElement.Name;
-                    var value = attrElement.Value.GetSingle();
+                    var value = attrElement.Value.GetSingle().ToString(CultureInfo.InvariantCulture);
 
                     builder.Line($"{{ \"{name}\", {value}f }}, ");
                 }

--- a/Obsidian.SourceGenerators/Registry/Models/Block.cs
+++ b/Obsidian.SourceGenerators/Registry/Models/Block.cs
@@ -56,8 +56,13 @@ internal sealed class Block : ITaggable, IHasName, IRegistryItem
             if (state.TryGetProperty("properties", out var jsonElement))
             {
                 var values = new List<string>();
-                foreach (var properties in jsonElement.EnumerateObject())
-                    values.Add(properties.Value.GetString().ToPascalCase());
+                foreach (JsonProperty jsonProperty in jsonElement.EnumerateObject())
+                {
+                    if (jsonProperty.Value.GetString() is string propertyValue)
+                    {
+                        values.Add(propertyValue.ToPascalCase());
+                    }
+                }
 
                 props.Add(id, values);
             }

--- a/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
+++ b/Obsidian.SourceGenerators/Registry/RegistryAssetsGenerator.cs
@@ -1,9 +1,6 @@
 ﻿using Obsidian.SourceGenerators.Registry.Models;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
-using System.Text.Json;
 
 namespace Obsidian.SourceGenerators.Registry;
 
@@ -12,34 +9,28 @@ public sealed partial class RegistryAssetsGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        //if (!Debugger.IsAttached)
-        //    Debugger.Launch();
-
-        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-
         var jsonFiles = context.AdditionalTextsProvider
             .Where(file => file.Path.EndsWith(".json"))
             .Select(static (file, ct) => (name: Path.GetFileNameWithoutExtension(file.Path), content: file.GetText(ct)!.ToString()));
 
         var compilation = context.CompilationProvider.Combine(jsonFiles.Collect());
 
-        context.RegisterSourceOutput(compilation, this.Generate);
+        context.RegisterSourceOutput(compilation, Generate);
     }
 
     private void Generate(SourceProductionContext context, (Compilation compilation, ImmutableArray<(string name, string json)> files) output)
     {
-        var asm = output.compilation.AssemblyName;
-
+        var assembly = output.compilation.AssemblyName;
         var assets = Assets.Get(output.files, context);
 
-        if (asm == "Obsidian")
+        if (assembly == "Obsidian")
         {
             GenerateTags(assets, context);
             GenerateItems(assets, context);
             GenerateBlockIds(assets, context);
             GenerateCodecs(assets, context);
         }
-        else if (asm == "Obsidian.API")
+        else if (assembly == "Obsidian.API")
         {
             GenerateMaterials(assets, context);
         }


### PR DESCRIPTION
Fixed all compiler warnings for the `Obsidian.SourceGenerators` project. Behavior should stay (almost) the same. Some code is awkward, because source generators cannot target the newest dotnet with all features.