### PR TITLE
Hotfix NbtWriter

### DIFF
--- a/Obsidian.Nbt/NbtWriter.cs
+++ b/Obsidian.Nbt/NbtWriter.cs
@@ -3,37 +3,23 @@ using System.IO.Compression;
 
 namespace Obsidian.Nbt;
 
-public partial struct NbtWriter : IDisposable, IAsyncDisposable
+public partial struct NbtWriter(Stream outstream, NbtCompression compressionMode = NbtCompression.None) : IDisposable, IAsyncDisposable
 {
-    private NbtTagType? expectedListType;
+    private ListData? currentListData;
     private NbtTagType? previousRootType;
 
-    private int listSize;
-    private int listIndex;
-    private int rootDepth;
+    internal int rootIndex = 0;
 
     public NbtTagType RootType { get; private set; }
 
-    public Stream BaseStream { get; }
+    public Stream BaseStream { get; } = compressionMode switch
+    {
+        NbtCompression.GZip => new GZipStream(outstream, CompressionMode.Compress),
+        NbtCompression.ZLib => new ZLibStream(outstream, CompressionMode.Compress),
+        _ => outstream
+    };
 
     public bool Networked { get; }
-
-    public NbtWriter(Stream outstream, NbtCompression compressionMode = NbtCompression.None)
-    {
-        this.BaseStream = compressionMode switch
-        {
-            NbtCompression.GZip => new GZipStream(outstream, CompressionMode.Compress),
-            NbtCompression.ZLib => new ZLibStream(outstream, CompressionMode.Compress),
-            _ => outstream
-        };
-
-        this.expectedListType = null;
-        this.previousRootType = null;
-
-        this.listSize = -1;
-        this.listIndex = -1;
-        this.rootDepth = 0;
-    }
 
     public NbtWriter(Stream outstream, string name) : this(outstream)
     {
@@ -60,21 +46,30 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
         this.SetRootTag(NbtTagType.Compound);
     }
 
-    private void SetRootTag(NbtTagType type)
+    private void SetRootTag(NbtTagType type, bool addRoot = true)
     {
-        this.rootDepth++;
+        if (addRoot)
+            this.rootIndex++;
 
         this.previousRootType = this.RootType;
         this.RootType = type;
     }
 
-    private void SetRootTag(NbtTagType type, int listSize, NbtTagType listType)
+    private void SetRootTag(NbtTagType type, int listSize, NbtTagType listType, bool addRoot = true)
     {
-        this.rootDepth++;
+        if (addRoot)
+            this.rootIndex++;
 
-        this.listIndex = 0;
-        this.listSize = listSize;
-        this.expectedListType = listType;
+        var previousListData = this.currentListData;
+        this.currentListData = new()
+        {
+            RootIndex = this.rootIndex,
+            ExpectedListType = listType,
+            ListSize = listSize,
+            ListIndex = 0,
+            PreviousListData = previousListData,
+            ParentTagType = this.RootType
+        };
 
         this.previousRootType = this.RootType;
         this.RootType = type;
@@ -114,18 +109,16 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
 
     public void EndList()
     {
-        if (this.listIndex < this.listSize)
+        if (this.currentListData!.ListIndex < this.currentListData?.ListSize)
             throw new InvalidOperationException("List cannot end because its size is smaller than the pre-defined size.");
 
         if (this.RootType != NbtTagType.List)
             throw new InvalidOperationException();
 
-        this.listSize = -1;
-        this.listIndex = -1;
-        this.expectedListType = null;
-        this.rootDepth--;
+        this.currentListData = this.currentListData.PreviousListData;
+        this.rootIndex--;
 
-        this.RootType = this.previousRootType ?? NbtTagType.End;
+        this.RootType = this.currentListData?.ParentTagType ?? this.previousRootType ?? NbtTagType.End;
 
         if (this.previousRootType != null)
             this.previousRootType = null;
@@ -136,10 +129,12 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
         if (this.RootType != NbtTagType.Compound)
             throw new InvalidOperationException();
 
-        this.rootDepth--;
-        if (this.expectedListType != null)
+        this.rootIndex--;
+        if (this.currentListData != null)
         {
-            this.SetRootTag(NbtTagType.List);
+            var tagType = this.currentListData.RootIndex == this.rootIndex ? NbtTagType.List : this.currentListData.ParentTagType ?? NbtTagType.End;
+            this.SetRootTag(tagType, false);
+            this.Write(NbtTagType.End);
 
             return;
         }
@@ -281,35 +276,33 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
         }
     }
 
-    public void WriteArray(INbtTag array)
+    public void WriteArray(string? name, Span<int> values)
     {
-        this.Validate(array.Name, array.Type);
+        this.Write(NbtTagType.IntArray);
+        this.WriteStringInternal(name);
+        this.WriteIntInternal(values.Length);
 
-        if (array is NbtArray<int> intArray)
-        {
-            this.Write(NbtTagType.IntArray);
-            this.WriteStringInternal(array.Name);
-            this.WriteIntInternal(intArray.Count);
+        for (int i = 0; i < values.Length; i++)
+            this.WriteIntInternal(values[i]);
+    }
 
-            for (int i = 0; i < intArray.Count; i++)
-                this.WriteIntInternal(intArray[i]);
-        }
-        else if (array is NbtArray<long> longArray)
-        {
-            this.Write(NbtTagType.LongArray);
-            this.WriteStringInternal(array.Name);
-            this.WriteIntInternal(longArray.Count);
+    public void WriteArray(string? name, Span<long> values)
+    {
+        this.Write(NbtTagType.Long);
+        this.WriteStringInternal(name);
+        this.WriteIntInternal(values.Length);
 
-            for (int i = 0; i < longArray.Count; i++)
-                this.WriteLongInternal(longArray[i]);
-        }
-        else if (array is NbtArray<byte> byteArray)
-        {
-            this.Write(NbtTagType.ByteArray);
-            this.WriteStringInternal(array.Name);
-            this.WriteIntInternal(byteArray.Count);
-            this.BaseStream.Write(byteArray.GetArray());
-        }
+        for (int i = 0; i < values.Length; i++)
+            this.WriteLongInternal(values[i]);
+    }
+
+    public void WriteArray(string? name, Span<byte> values)
+    {
+        this.Write(NbtTagType.ByteArray);
+        this.WriteStringInternal(name);
+        this.WriteIntInternal(values.Length);
+
+        this.BaseStream.Write(values);
     }
 
     public void Validate(string name, NbtTagType type)
@@ -317,16 +310,16 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
         if (this.RootType == NbtTagType.List)
         {
             if (!string.IsNullOrWhiteSpace(name))
-                throw new InvalidOperationException($"Use the Write{type}({type.ToString().ToLower()} value) method when writing to lists");
+                throw new InvalidOperationException("Tags inside lists cannot be named.");
 
-            if (this.expectedListType != type)
-                throw new InvalidOperationException($"Expected list type: {this.expectedListType}. Got: {type}");
+            if (this.currentListData!.ExpectedListType != type)
+                throw new InvalidOperationException($"Expected list type: {this.currentListData!.ExpectedListType}. Got: {type}");
             else if (!string.IsNullOrEmpty(name))
                 throw new InvalidOperationException("Tags inside lists must be nameless.");
-            else if (this.listIndex > this.listSize)
+            else if (this.currentListData!.ListIndex > this.currentListData!.ListSize)
                 throw new IndexOutOfRangeException("Exceeded pre-defined list size");
 
-            this.listIndex++;
+            this.currentListData!.ListIndex++;
         }
         else if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException($"Tags inside a compound tag must have a name. Tag({type})");
@@ -334,15 +327,15 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
 
     public void TryFinish()
     {
-        if (this.rootDepth > 0)
-            throw new InvalidOperationException("Unable to close writer. Root tag has yet to be closed.");//TODO maybe more info here??
+        if (this.rootIndex > 0)
+            throw new InvalidOperationException($"Unable to close writer. Root tag has yet to be closed. rootDept == {this.rootIndex}");//TODO maybe more info here??
 
         this.BaseStream.Flush();
     }
 
     public async Task TryFinishAsync()
     {
-        if (this.rootDepth > 0)
+        if (this.rootIndex > 0)
             throw new InvalidOperationException("Unable to close writer. Root tag has yet to be closed.");//TODO maybe more info here??
 
         await this.BaseStream.FlushAsync();
@@ -350,4 +343,37 @@ public partial struct NbtWriter : IDisposable, IAsyncDisposable
 
     public ValueTask DisposeAsync() => this.BaseStream.DisposeAsync();
     public void Dispose() => this.BaseStream.Dispose();
+
+    private void WriteArray(INbtTag array)
+    {
+        this.Validate(array.Name, array.Type);
+
+        if (array is NbtArray<int> intArray)
+        {
+            this.WriteArray(intArray.Name, intArray.GetArray());
+        }
+        else if (array is NbtArray<long> longArray)
+        {
+            this.WriteArray(longArray.Name, longArray.GetArray());
+        }
+        else if (array is NbtArray<byte> byteArray)
+        {
+            this.WriteArray(byteArray.Name, byteArray.GetArray());
+        }
+    }
+
+    private sealed class ListData
+    {
+        public required int RootIndex { get; init; }
+
+        public required int ListSize { get; init; }
+
+        public required int ListIndex { get; set; }
+
+        public required NbtTagType ExpectedListType { get; init; }
+
+        public required ListData? PreviousListData { get; init; }
+
+        public required NbtTagType? ParentTagType { get; init; }
+    }
 }

--- a/Obsidian.Nbt/NbtWriter.cs
+++ b/Obsidian.Nbt/NbtWriter.cs
@@ -309,7 +309,8 @@ public partial struct NbtWriter(Stream outstream, NbtCompression compressionMode
 
     public void Validate(string name, NbtTagType type)
     {
-        this.TryValidateList(name, type);
+        if (this.TryValidateList(name, type))
+            return;
 
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException($"Tags inside a compound tag must have a name. Tag({type})");
@@ -320,10 +321,10 @@ public partial struct NbtWriter(Stream outstream, NbtCompression compressionMode
         this.compoundChildren.Add(name);
     }
 
-    private void TryValidateList(string name, NbtTagType type)
+    private bool TryValidateList(string name, NbtTagType type)
     {
         if (this.RootType != NbtTagType.List)
-            return;
+            return false;
 
         if (!string.IsNullOrWhiteSpace(name))
             throw new InvalidOperationException("Tags inside lists cannot be named.");
@@ -336,6 +337,8 @@ public partial struct NbtWriter(Stream outstream, NbtCompression compressionMode
             throw new IndexOutOfRangeException("Exceeded pre-defined list size");
 
         this.currentListData!.ListIndex++;
+
+        return true;
     }
 
     public void TryFinish()

--- a/Obsidian.Tests/Nbt.cs
+++ b/Obsidian.Tests/Nbt.cs
@@ -8,10 +8,12 @@ namespace Obsidian.Tests;
 
 public class Nbt(ITestOutputHelper output)
 {
+    private Stream? stream;
+
     [Fact]
-    public void BigTest()
+    public void ReadBigTest()
     {
-        var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("Obsidian.Tests.Assets.bigtest.nbt");
+        var fs = stream ?? Assembly.GetExecutingAssembly().GetManifestResourceStream("Obsidian.Tests.Assets.bigtest.nbt");
 
         var reader = new NbtReader(fs, NbtCompression.GZip);
 
@@ -100,6 +102,99 @@ public class Nbt(ITestOutputHelper output)
         Assert.Equal("Compound tag #1", compound2.GetString("name"));
         Assert.Equal(1264099775885, compound2.GetLong("created-on"));
         #endregion lists
+    }
+
+
+    [Fact]
+    public void WriteBigTest()
+    {
+        this.stream = new MemoryStream();
+        using var writer = new NbtWriter(stream, NbtCompression.GZip, "Level");
+
+        Assert.Equal(1, writer.rootIndex);
+        {
+            writer.WriteCompoundStart("nested compound test");
+            Assert.Equal(2, writer.rootIndex);
+            {
+                writer.WriteCompoundStart("egg");
+                Assert.Equal(3, writer.rootIndex);
+                {
+                    writer.WriteString("name", "Eggbert");
+                    writer.WriteFloat("value", 0.5f);
+                }
+                writer.EndCompound();
+                Assert.Equal(2, writer.rootIndex);
+
+                writer.WriteCompoundStart("ham");
+                Assert.Equal(3, writer.rootIndex);
+                {
+                    writer.WriteString("name", "Hampus");
+                    writer.WriteFloat("value", 0.75f);
+                }
+                writer.EndCompound();
+                Assert.Equal(2, writer.rootIndex);
+            }
+            writer.EndCompound();
+            Assert.Equal(1, writer.rootIndex);
+
+            writer.WriteInt("intTest", int.MaxValue);
+            writer.WriteByte("byteTest", (byte)sbyte.MaxValue);
+            writer.WriteString("stringTest", "HELLO WORLD THIS IS A TEST STRING \xc5\xc4\xd6!");
+
+            writer.WriteListStart("listTest (long)", NbtTagType.Long, 5);
+            Assert.Equal(2, writer.rootIndex);
+            {
+                for (int i = 0; i < 5; i++)
+                    writer.WriteLong(11 + i);
+            }
+            writer.EndList();
+            Assert.Equal(1, writer.rootIndex);
+
+            writer.WriteDouble("doubleTest", 0.49312871321823148);
+            writer.WriteFloat("floatTest", 0.49823147058486938f);
+            writer.WriteLong("longTest", long.MaxValue);
+            writer.WriteShort("shortTest", short.MaxValue);
+
+            writer.WriteListStart("listTest (compound)", NbtTagType.Compound, 2);
+            Assert.Equal(2, writer.rootIndex);
+            {
+                writer.WriteCompoundStart();
+                Assert.Equal(3, writer.rootIndex);
+                {
+                    writer.WriteLong("created-on", 1264099775885L);
+                    writer.WriteString("name", "Compound tag #0");
+                }
+                writer.EndCompound();
+                Assert.Equal(2, writer.rootIndex);
+
+                writer.WriteCompoundStart();
+                Assert.Equal(3, writer.rootIndex);
+                {
+                    writer.WriteLong("created-on", 1264099775885L);
+                    writer.WriteString("name", "Compound tag #1");
+                }
+                writer.EndCompound();
+                Assert.Equal(2, writer.rootIndex);
+            }
+            writer.EndList();
+
+            Assert.Equal(1, writer.rootIndex);
+            Assert.Equal(NbtTagType.Compound, writer.RootType);
+
+            var array = new byte[1000];
+            for (int n = 0; n < 1000; n++)
+                array[n] = (byte)((n * n * 255 + n * 7) % 100);
+
+            writer.WriteArray("byteArrayTest (the first 1000 values of (n*n*255+n*7)%100, starting with n=0 (0, 62, 34, 16, 8, ...))", array);
+        }
+        writer.EndCompound();
+        Assert.Equal(0, writer.rootIndex);
+
+        writer.TryFinish();
+
+        this.stream.Position = 0;
+
+        this.ReadBigTest();
     }
 
     [Fact]

--- a/Obsidian.Tests/Nbt.cs
+++ b/Obsidian.Tests/Nbt.cs
@@ -110,45 +110,35 @@ public class Nbt(ITestOutputHelper output)
     {
         this.stream = new MemoryStream();
         using var writer = new NbtWriter(stream, NbtCompression.GZip, "Level");
-
-        Assert.Equal(1, writer.rootIndex);
         {
             writer.WriteCompoundStart("nested compound test");
-            Assert.Equal(2, writer.rootIndex);
             {
                 writer.WriteCompoundStart("egg");
-                Assert.Equal(3, writer.rootIndex);
                 {
                     writer.WriteString("name", "Eggbert");
                     writer.WriteFloat("value", 0.5f);
                 }
                 writer.EndCompound();
-                Assert.Equal(2, writer.rootIndex);
 
                 writer.WriteCompoundStart("ham");
-                Assert.Equal(3, writer.rootIndex);
                 {
                     writer.WriteString("name", "Hampus");
                     writer.WriteFloat("value", 0.75f);
                 }
                 writer.EndCompound();
-                Assert.Equal(2, writer.rootIndex);
             }
             writer.EndCompound();
-            Assert.Equal(1, writer.rootIndex);
 
             writer.WriteInt("intTest", int.MaxValue);
             writer.WriteByte("byteTest", (byte)sbyte.MaxValue);
             writer.WriteString("stringTest", "HELLO WORLD THIS IS A TEST STRING \xc5\xc4\xd6!");
 
             writer.WriteListStart("listTest (long)", NbtTagType.Long, 5);
-            Assert.Equal(2, writer.rootIndex);
             {
                 for (int i = 0; i < 5; i++)
                     writer.WriteLong(11 + i);
             }
             writer.EndList();
-            Assert.Equal(1, writer.rootIndex);
 
             writer.WriteDouble("doubleTest", 0.49312871321823148);
             writer.WriteFloat("floatTest", 0.49823147058486938f);
@@ -156,29 +146,23 @@ public class Nbt(ITestOutputHelper output)
             writer.WriteShort("shortTest", short.MaxValue);
 
             writer.WriteListStart("listTest (compound)", NbtTagType.Compound, 2);
-            Assert.Equal(2, writer.rootIndex);
             {
                 writer.WriteCompoundStart();
-                Assert.Equal(3, writer.rootIndex);
                 {
                     writer.WriteLong("created-on", 1264099775885L);
                     writer.WriteString("name", "Compound tag #0");
                 }
                 writer.EndCompound();
-                Assert.Equal(2, writer.rootIndex);
 
                 writer.WriteCompoundStart();
-                Assert.Equal(3, writer.rootIndex);
                 {
                     writer.WriteLong("created-on", 1264099775885L);
                     writer.WriteString("name", "Compound tag #1");
                 }
                 writer.EndCompound();
-                Assert.Equal(2, writer.rootIndex);
             }
             writer.EndList();
 
-            Assert.Equal(1, writer.rootIndex);
             Assert.Equal(NbtTagType.Compound, writer.RootType);
 
             var array = new byte[1000];
@@ -188,7 +172,6 @@ public class Nbt(ITestOutputHelper output)
             writer.WriteArray("byteArrayTest (the first 1000 values of (n*n*255+n*7)%100, starting with n=0 (0, 62, 34, 16, 8, ...))", array);
         }
         writer.EndCompound();
-        Assert.Equal(0, writer.rootIndex);
 
         writer.TryFinish();
 

--- a/Obsidian/WorldData/Region.cs
+++ b/Obsidian/WorldData/Region.cs
@@ -332,8 +332,8 @@ public class Region : IRegion
         writer.EndList();
 
         writer.WriteInt("xPos", chunk.X);
-        writer.WriteInt("xPos", chunk.Z);
-        writer.WriteInt("xPos", -4);
+        writer.WriteInt("zPos", chunk.Z);
+        writer.WriteInt("yPos", -4);
         writer.WriteInt("DataVersion", 3337);
         writer.WriteString("Status", chunk.chunkStatus.ToString());
 


### PR DESCRIPTION
This just fixes NbtWriter not being aware of lists and cleans up the SerializeChunk method to use NbtWriter directly instead of writing tag classes directly