### PR TITLE
Fix a couple of nbt exceptions

### DIFF
--- a/Obsidian.API/_Interfaces/IEntity.cs
+++ b/Obsidian.API/_Interfaces/IEntity.cs
@@ -22,7 +22,7 @@ public interface IEntity
 
     public BoundingBox BoundingBox { get; }
     public EntityDimension Dimension { get; }
-    public int Air { get; set; }
+    public short Air { get; set; }
 
     public float Health { get; set; }
 

--- a/Obsidian.Nbt/NbtCompound.cs
+++ b/Obsidian.Nbt/NbtCompound.cs
@@ -46,7 +46,7 @@ public sealed class NbtCompound : INbtTag, IEnumerable<KeyValuePair<string, INbt
     public bool TryGetTag(string name, [MaybeNullWhen(false)] out INbtTag tag) => this.children.TryGetValue(name, out tag);
     public bool TryGetTag<T>(string name, [MaybeNullWhen(false)] out T tag) where T : INbtTag
     {
-        if (this.children.TryGetValue(name, out var childTag) && childTag is T matchedTag)
+        if (this.TryGetTag(name, out var childTag) && childTag is T matchedTag)
         {
             tag = matchedTag;
             return true;
@@ -55,18 +55,18 @@ public sealed class NbtCompound : INbtTag, IEnumerable<KeyValuePair<string, INbt
         tag = default;
         return false;
     }
-    public bool TryGetTagValue<TValue>(string name, [MaybeNullWhen(false)]out TValue value)
+
+    public bool TryGetTagValue<TValue>(string name, [MaybeNullWhen(false)] out TValue value)
     {
-        if(this.GetTagValue<TValue>(name) is TValue tagValue)
+        if (this.TryGetTag(name, out var tag) && tag is NbtTag<TValue> actualTag)
         {
-            value = tagValue;
+            value = actualTag.Value;
             return true;
         }
 
         value = default;
         return false;
     }
-
 
     public byte GetByte(string name) => this.GetTagValue<byte>(name);
 
@@ -149,11 +149,5 @@ public sealed class NbtCompound : INbtTag, IEnumerable<KeyValuePair<string, INbt
 
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
-    private T? GetTagValue<T>(string name)
-    {
-        if (this.TryGetTag(name, out var tag) && tag is NbtTag<T> actualTag)
-            return actualTag.Value;
-
-        throw new TagNotFoundException(name);
-    }
+    private T? GetTagValue<T>(string name) => this.TryGetTag(name, out var tag) && tag is NbtTag<T> actualTag ? actualTag.Value : throw new TagNotFoundException(name);
 }

--- a/Obsidian.Nbt/NbtCompound.cs
+++ b/Obsidian.Nbt/NbtCompound.cs
@@ -58,9 +58,9 @@ public sealed class NbtCompound : INbtTag, IEnumerable<KeyValuePair<string, INbt
 
     public bool TryGetTagValue<TValue>(string name, [MaybeNullWhen(false)] out TValue value)
     {
-        if (this.TryGetTag(name, out var tag) && tag is NbtTag<TValue> actualTag)
+        if (this.TryGetTag<NbtTag<TValue>>(name, out var tag))
         {
-            value = actualTag.Value;
+            value = tag.Value;
             return true;
         }
 

--- a/Obsidian/Entities/Entity.cs
+++ b/Obsidian/Entities/Entity.cs
@@ -39,7 +39,7 @@ public class Entity : IEquatable<Entity>, IEntity
 
     public EntityType Type { get; set; }
 
-    public int Air { get; set; } = 300;
+    public short Air { get; set; } = 300;
 
     public float Health { get; set; } = 100;
 

--- a/Obsidian/Entities/Player.Helpers.cs
+++ b/Obsidian/Entities/Player.Helpers.cs
@@ -51,6 +51,8 @@ public partial class Player
         writer.WriteInt("XpLevel", XpLevel);
         writer.WriteInt("XpTotal", XpTotal);
 
+        writer.WriteShort("Air", Air);
+
         writer.WriteFloat("Health", Health);
 
         writer.WriteFloat("foodExhaustionLevel", FoodExhaustionLevel);

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -584,7 +584,7 @@ public partial class MinecraftStream : INetStreamReader
         var reader = new NbtReader(this);
         var chatMessage = ChatMessage.Empty;
 
-        return !reader.TryReadNextTag<NbtCompound>(out var root) ? chatMessage : chatMessage.FromNbt(root);
+        return !reader.TryReadNextTag<NbtCompound>(false, out var root) ? chatMessage : chatMessage.FromNbt(root);
     }
 
     [ReadMethod]


### PR DESCRIPTION
Fixes TagNotFoundException when using NbtReader.TryGetTag and NbtReader.TryGetTagValue as these aren't supposed to be throwing exceptions (WIll fix that random TagNotFoundException that's thrown when a player joins the server)