### PR TITLE
Implement some clientbound packets

### DIFF
--- a/Obsidian.API/_Interfaces/INetworkSerializable.cs
+++ b/Obsidian.API/_Interfaces/INetworkSerializable.cs
@@ -1,6 +1,24 @@
 ﻿namespace Obsidian.API;
+
+/// <summary>
+/// Interface for network serializable objects. Due to the nature of Obsidian being a server-side only software,
+/// both <see cref="Write"/> and <see cref="Read"/> methods are not always necessary to implement. In that case,
+/// a <see cref="NotImplementedException"/> is thrown when the method is unintendedly called.
+/// </summary>
+/// <typeparam name="TValue">Type of the value to be serialized.</typeparam>
 public interface INetworkSerializable<TValue>
 {
+    /// <summary>
+    /// Writes the value to the network stream.
+    /// </summary>
+    /// <param name="value">Value to be serialized.</param>
+    /// <param name="writer">Network stream writer.</param>
     public static abstract void Write(TValue value, INetStreamWriter writer);
+
+    /// <summary>
+    /// Reads the value from the network stream.
+    /// </summary>
+    /// <param name="reader">Network stream reader.</param>
+    /// <returns>Deserialized value.</returns>
     public static abstract TValue Read(INetStreamReader reader);
 }

--- a/Obsidian.API/_Interfaces/IPacket.cs
+++ b/Obsidian.API/_Interfaces/IPacket.cs
@@ -1,10 +1,24 @@
 ﻿namespace Obsidian.API;
+
+/// <summary>
+/// Represents a network packet that can be transferred between the client and the server.
+/// </summary>
 public interface IPacket
 {
+    /// <summary>
+    /// The ID of the packet.
+    /// </summary>
     public int Id { get; }
 }
 
+/// <summary>
+/// Represents a network packet that can be sent to the client by the server.
+/// </summary>
 public interface IClientboundPacket : IPacket
 {
+    /// <summary>
+    /// Writes the data content of the packet to the stream.
+    /// </summary>
+    /// <param name="writer">The stream writer to write the data to.</param>
     public void Serialize(INetStreamWriter writer);
 }

--- a/Obsidian.API/_Types/TradeEntry.cs
+++ b/Obsidian.API/_Types/TradeEntry.cs
@@ -5,7 +5,7 @@ namespace Obsidian.API;
 /// <summary>
 /// Represents a trade entry offered by a villager or wandering trader.
 /// </summary>
-public sealed record TradeEntry
+public sealed record TradeEntry : INetworkSerializable<TradeEntry>
 {
     /// <summary>
     /// The first input item of the trade. The required count of the first input is the "base price" of the trade.
@@ -28,7 +28,7 @@ public sealed record TradeEntry
     /// Whether the trade is disabled.
     /// </summary>
     public bool IsDisabled { get; set; }
-    
+
     /// <summary>
     /// Number of times the trade has been used.
     /// </summary>
@@ -59,21 +59,20 @@ public sealed record TradeEntry
     /// </summary>
     public int Demand { get; set; }
 
-    /// <summary>
-    /// Writes the data to an <see cref="INetStreamWriter"/>.
-    /// </summary>
-    /// <param name="writer">The writer to write to.</param>
-    public void Write(INetStreamWriter writer)
+    public static void Write(TradeEntry value, INetStreamWriter writer)
     {
-        FirstInput.Write(writer);
-        writer.WriteItemStack(Output);
-        SecondInput.Write(writer);
-        writer.WriteBoolean(IsDisabled);
-        writer.WriteInt(UsedCount);
-        writer.WriteInt(MaxCount);
-        writer.WriteInt(XP);
-        writer.WriteInt(Discount);
-        writer.WriteFloat(Multiplier);
-        writer.WriteInt(Demand);
+        TradeItem.Write(value.FirstInput, writer);
+        writer.WriteItemStack(value.Output);
+        TradeItem.Write(value.SecondInput, writer);
+        writer.WriteBoolean(value.IsDisabled);
+        writer.WriteInt(value.UsedCount);
+        writer.WriteInt(value.MaxCount);
+        writer.WriteInt(value.XP);
+        writer.WriteInt(value.Discount);
+        writer.WriteFloat(value.Multiplier);
+        writer.WriteInt(value.Demand);
     }
+
+    // No need to implement
+    public static TradeEntry Read(INetStreamReader reader) => throw new NotImplementedException();
 }

--- a/Obsidian.API/_Types/TradeEntry.cs
+++ b/Obsidian.API/_Types/TradeEntry.cs
@@ -1,0 +1,79 @@
+using Obsidian.API.Inventory;
+
+namespace Obsidian.API;
+
+/// <summary>
+/// Represents a trade entry offered by a villager or wandering trader.
+/// </summary>
+public sealed record TradeEntry
+{
+    /// <summary>
+    /// The first input item of the trade. The required count of the first input is the "base price" of the trade.
+    /// The final price = base + floor(base * <see cref="Multiplier"/> * <see cref="Demand"/>) + <see cref="Discount"/>.
+    /// </summary>
+    public TradeItem FirstInput { get; set; }
+
+    /// <summary>
+    /// The output item of the trade.
+    /// </summary>
+    public ItemStack Output { get; set; }
+
+    /// <summary>
+    /// The second input item of the trade. The required count of the second input is not affected by discount
+    /// or demand.
+    /// </summary>
+    public TradeItem SecondInput { get; set; }
+
+    /// <summary>
+    /// Whether the trade is disabled.
+    /// </summary>
+    public bool IsDisabled { get; set; }
+    
+    /// <summary>
+    /// Number of times the trade has been used.
+    /// </summary>
+    public int UsedCount { get; set; }
+
+    /// <summary>
+    /// The maximum number of times the trade can be used before it becomes disabled.
+    /// </summary>
+    public int MaxCount { get; set; }
+
+    /// <summary>
+    /// Number of XPs the villager will earn after each trade.
+    /// </summary>
+    public int XP { get; set; }
+
+    /// <summary>
+    /// Used in calculating the final price. Can be zero or negative.
+    /// </summary>
+    public int Discount { get; set; }
+
+    /// <summary>
+    /// Used in calculating the final price. Can be low (0.05) or high (0.2).
+    /// </summary>
+    public float Multiplier { get; set; }
+
+    /// <summary>
+    /// Used in calculating the final price. Negative values are treated as zero.
+    /// </summary>
+    public int Demand { get; set; }
+
+    /// <summary>
+    /// Writes the data to an <see cref="INetStreamWriter"/>.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    public void Write(INetStreamWriter writer)
+    {
+        FirstInput.Write(writer);
+        writer.WriteItemStack(Output);
+        SecondInput.Write(writer);
+        writer.WriteBoolean(IsDisabled);
+        writer.WriteInt(UsedCount);
+        writer.WriteInt(MaxCount);
+        writer.WriteInt(XP);
+        writer.WriteInt(Discount);
+        writer.WriteFloat(Multiplier);
+        writer.WriteInt(Demand);
+    }
+}

--- a/Obsidian.API/_Types/TradeItem.cs
+++ b/Obsidian.API/_Types/TradeItem.cs
@@ -1,0 +1,53 @@
+using Obsidian.API.Inventory;
+
+namespace Obsidian.API;
+
+/// <summary>
+/// Represents an item stack supplied as the "price" in a <see cref="TradeEntry"/>.
+/// </summary>
+public sealed record TradeItem
+{
+    /// <summary>
+    /// The item ID.
+    /// </summary>
+    public int ID { get; set; }
+
+    /// <summary>
+    /// The item count.
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>
+    /// The item's components. An item stack must match all the component requirements to be considered a
+    /// valid input.
+    /// </summary>
+    public List<IDataComponent> Components { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TradeItem"/> record.
+    /// </summary>
+    /// <param name="id">The item ID.</param>
+    /// <param name="count">The item count.</param>
+    /// <param name="components">The item's components.</param>
+    public TradeItem(int id, int count, List<IDataComponent> components)
+    {
+        ID = id;
+        Count = count;
+        Components = components;
+    }
+
+    /// <summary>
+    /// Writes the data to an <see cref="INetStreamWriter"/>.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    public void Write(INetStreamWriter writer)
+    {
+        writer.WriteVarInt(ID);
+        writer.WriteVarInt(Count);
+        writer.WriteLengthPrefixedArray((c) =>
+        {
+            writer.WriteVarInt(c.Type);
+            c.Write(writer);
+        }, Components);
+    }
+}

--- a/Obsidian.API/_Types/TradeItem.cs
+++ b/Obsidian.API/_Types/TradeItem.cs
@@ -5,7 +5,7 @@ namespace Obsidian.API;
 /// <summary>
 /// Represents an item stack supplied as the "price" in a <see cref="TradeEntry"/>.
 /// </summary>
-public sealed record TradeItem
+public sealed record TradeItem : INetworkSerializable<TradeItem>
 {
     /// <summary>
     /// The item ID.
@@ -36,18 +36,17 @@ public sealed record TradeItem
         Components = components;
     }
 
-    /// <summary>
-    /// Writes the data to an <see cref="INetStreamWriter"/>.
-    /// </summary>
-    /// <param name="writer">The writer to write to.</param>
-    public void Write(INetStreamWriter writer)
+    public static void Write(TradeItem value, INetStreamWriter writer)
     {
-        writer.WriteVarInt(ID);
-        writer.WriteVarInt(Count);
+        writer.WriteVarInt(value.ID);
+        writer.WriteVarInt(value.Count);
         writer.WriteLengthPrefixedArray((c) =>
         {
             writer.WriteVarInt(c.Type);
             c.Write(writer);
-        }, Components);
+        }, value.Components);
     }
+
+    // No need to implement
+    public static TradeItem Read(INetStreamReader reader) => throw new NotImplementedException();
 }

--- a/Obsidian/Entities/Entity.cs
+++ b/Obsidian/Entities/Entity.cs
@@ -400,26 +400,26 @@ public class Entity : IEquatable<Entity>, IEntity
     public virtual void SpawnEntity(Velocity? velocity = null, int additionalData = 0)
     {
         this.PacketBroadcaster.QueuePacketToWorldInRange(this.World, this.Position, new BundledPacket
-        {
-            Packets = [
-                        new AddEntityPacket
-                        {
-                            EntityId = this.EntityId,
-                            Uuid = this.Uuid,
-                            Type = this.Type,
-                            Position = this.Position,
-                            Pitch = this.Pitch,
-                            Yaw = this.Yaw,
-                            Data = additionalData,
-                            Velocity = velocity ?? new Velocity(0, 0, 0)
-                        },
-                        new SetEntityDataPacket
-                        {
-                            EntityId = this.EntityId,
-                            Entity = this
-                        }
-                    ]
-        }, this.EntityId);
+        (
+             [
+                new AddEntityPacket
+                {
+                    EntityId = this.EntityId,
+                    Uuid = this.Uuid,
+                    Type = this.Type,
+                    Position = this.Position,
+                    Pitch = this.Pitch,
+                    Yaw = this.Yaw,
+                    Data = additionalData,
+                    Velocity = velocity ?? new Velocity(0, 0, 0)
+                },
+                new SetEntityDataPacket
+                {
+                    EntityId = this.EntityId,
+                    Entity = this
+                }
+            ]
+        ), this.EntityId);
     }
 
     public bool TryAddAttribute(string attributeResourceName, float value) =>

--- a/Obsidian/Net/Packets/Play/Clientbound/BundleDelimiterPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/BundleDelimiterPacket.cs
@@ -1,0 +1,7 @@
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Used to wrap a <see cref="BundledPacket"/>.
+/// </summary>
+public partial class BundleDelimiterPacket
+{ }

--- a/Obsidian/Net/Packets/Play/Clientbound/BundledPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/BundledPacket.cs
@@ -1,7 +1,16 @@
 ﻿namespace Obsidian.Net.Packets.Play.Clientbound;
-public partial class BundledPacket : ClientboundPacket
+
+/// <summary>
+/// Represents a bundle of packets that the client should handle in the same tick.
+/// A <see cref="BundleDelimiterPacket"/> is sent before and after the content packets are sent to the client.
+/// Vanilla Minecraft client doesn't allow more than 4096 packets in one bundle.
+/// </summary>
+public partial class BundledPacket(List<ClientboundPacket> packets) : ClientboundPacket
 {
-    public required List<ClientboundPacket> Packets { get; set; }
+    /// <summary>
+    /// The packets in this bundle.
+    /// </summary>
+    public List<ClientboundPacket> Packets { get; set; } = packets;
 
     public override int Id => 0;
 

--- a/Obsidian/Net/Packets/Play/Clientbound/HorseScreenOpenPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/HorseScreenOpenPacket.cs
@@ -1,0 +1,40 @@
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent to tell the client to open the horse GUI. Opening other GUIs are done via <see cref="OpenScreenPacket"/>.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="HorseScreenOpenPacket"/> class.
+/// </remarks>
+/// <param name="windowId">The identifier of the window to open.</param>
+/// <param name="columnCount">How many columns the horse inventory should have.</param>
+/// <param name="entityId">The owner entity of the window.</param>
+public partial class HorseScreenOpenPacket(int windowId, int columnCount, int entityId)
+{
+    /// <summary>
+    /// The identifier of the window to open.
+    /// </summary>
+    [Field(0), VarLength]
+    public int WindowID { get; set; } = windowId;
+
+    /// <summary>
+    /// How many columns the horse inventory should have.
+    /// </summary>
+    [Field(1), VarLength]
+    public int ColumnCount { get; set; } = columnCount;
+
+    /// <summary>
+    /// The owner entity of the window.
+    /// </summary>
+    [Field(2)]
+    public int EntityID { get; set; } = entityId;
+
+    public override void Serialize(INetStreamWriter writer) 
+    {
+        writer.WriteVarInt(WindowID);
+        writer.WriteVarInt(ColumnCount);
+        writer.WriteInt(EntityID);
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/MerchantOffersPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/MerchantOffersPacket.cs
@@ -1,0 +1,56 @@
+using Obsidian.API;
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// The list of trades a villager is offering.
+/// </summary>
+public partial class MerchantOffersPacket
+{
+    /// <summary>
+    /// The window ID of the villager's trade list.
+    /// </summary>
+    [Field(0), VarLength]
+    public int WindowId { get; set; }
+
+    /// <summary>
+    /// The offered trades list.
+    /// </summary>
+    [Field(1)]
+    public List<TradeEntry> Offers { get; set; }
+
+    /// <summary>
+    /// The level of the villager. 1: Novice, 2: Apprentice, 3: Journeyman, 4: Expert, 5: Master.
+    /// </summary>
+    [Field(2), VarLength]
+    public int VillagerLevel { get; set; }
+
+    /// <summary>
+    /// The total experience of the villager. Always 0 for wandering traders.
+    /// </summary>
+    [Field(3), VarLength]
+    public int VillagerExperience { get; set; }
+
+    /// <summary>
+    /// True if the villager is a regular villager, false if it is a wandering trader.
+    /// </summary>
+    [Field(4)]
+    public bool IsRegularVillager { get; set; }
+
+    /// <summary>
+    /// True if the villager can restock their inventory, false otherwise.
+    /// </summary>
+    [Field(5)]
+    public bool CanRestock { get; set; }
+
+    public override void Serialize(INetStreamWriter writer)
+    {
+        writer.WriteVarInt(WindowId);
+        writer.WriteLengthPrefixedArray((o) => o.Write(writer), Offers);
+        writer.WriteVarInt(VillagerLevel);
+        writer.WriteVarInt(VillagerExperience);
+        writer.WriteBoolean(IsRegularVillager);
+        writer.WriteBoolean(CanRestock);
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/MerchantOffersPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/MerchantOffersPacket.cs
@@ -47,7 +47,7 @@ public partial class MerchantOffersPacket
     public override void Serialize(INetStreamWriter writer)
     {
         writer.WriteVarInt(WindowId);
-        writer.WriteLengthPrefixedArray((o) => o.Write(writer), Offers);
+        writer.WriteLengthPrefixedArray((o) => TradeEntry.Write(o, writer), Offers);
         writer.WriteVarInt(VillagerLevel);
         writer.WriteVarInt(VillagerExperience);
         writer.WriteBoolean(IsRegularVillager);

--- a/Obsidian/Net/Packets/Play/Clientbound/OpenBookPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/OpenBookPacket.cs
@@ -2,8 +2,14 @@
 
 namespace Obsidian.Net.Packets.Play.Clientbound;
 
+/// <summary>
+/// Sent to the client to open a book GUI.
+/// </summary>
 public partial class OpenBookPacket
 {
+    /// <summary>
+    /// The hand that is holding the book.
+    /// </summary>
     [Field(0), ActualType(typeof(int)), VarLength]
     public Hand Hand { get; set; }
 

--- a/Obsidian/Net/Packets/Play/Clientbound/OpenSignEditorPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/OpenSignEditorPacket.cs
@@ -1,0 +1,23 @@
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent to tell the client to open the sign editor screen.
+/// </summary>
+public partial class OpenSignEditorPacket
+{
+    /// <summary>
+    /// The location of the sign to edit.
+    /// </summary>
+    public VectorF Location { get; set; }
+
+    /// <summary>
+    /// True if the editor is opened for the front text, false for the back text.
+    /// </summary>
+    public bool IsFrontText { get; set; }
+
+    public override void Serialize(INetStreamWriter writer)
+    {
+        writer.WritePositionF(Location);
+        writer.WriteBoolean(IsFrontText);
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatEndPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatEndPacket.cs
@@ -1,0 +1,20 @@
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent when a player exits the combat state. This packet is unused by the vanilla Minecraft client.
+/// </summary>
+public partial class PlayerCombatEndPacket
+{
+    /// <summary>
+    /// The duration of the combat state in ticks.
+    /// </summary>
+    [Field(0), VarLength]
+    public int Duration { get; set; }
+
+    public override void Serialize(INetStreamWriter writer)
+    {
+        writer.WriteVarInt(Duration);
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatEnterPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatEnterPacket.cs
@@ -1,0 +1,7 @@
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent when a player enters the combat state. This packet is unused by the vanilla Minecraft client.
+/// </summary>
+public partial class PlayerCombatEnterPacket
+{ }

--- a/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatKillPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/PlayerCombatKillPacket.cs
@@ -1,0 +1,23 @@
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent to tell the client to show the respawn screen.
+/// </summary>
+public partial class PlayerCombatKillPacket
+{
+    /// <summary>
+    /// Entity ID of the dead player. Should match the ID on the client.
+    /// </summary>
+    public int PlayerID { get; set; }
+
+    /// <summary>
+    /// The death message to display.
+    /// </summary>
+    public ChatMessage Message { get; set; }
+
+    public override void Serialize(INetStreamWriter writer)
+    {
+        writer.WriteVarInt(PlayerID);
+        writer.WriteChat(Message);
+    }
+}

--- a/Obsidian/Net/Packets/Play/Clientbound/SetChunkCacheRadiusPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/SetChunkCacheRadiusPacket.cs
@@ -1,0 +1,20 @@
+using Obsidian.Serialization.Attributes;
+
+namespace Obsidian.Net.Packets.Play.Clientbound;
+
+/// <summary>
+/// Sent to change the view distance of the client.
+/// </summary>
+public partial class SetChunkCacheRadiusPacket
+{
+    /// <summary>
+    /// The new view distance.
+    /// </summary>
+    [Field(0), VarLength]
+    public int ViewDistance { get; set; }
+
+    public override void Serialize(INetStreamWriter writer)
+    {
+        writer.WriteVarInt(ViewDistance);
+    }
+}

--- a/Obsidian/Serialization/Attributes/FieldAttribute.cs
+++ b/Obsidian/Serialization/Attributes/FieldAttribute.cs
@@ -1,9 +1,22 @@
 ﻿namespace Obsidian.Serialization.Attributes;
 
+/// <summary>
+/// Defines the attributes of a field in a packet.
+/// </summary>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 public sealed class FieldAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FieldAttribute"/> class.
+    /// </summary>
+    /// <param name="order">The order of the field when serializing or deserializing the packet. Starts from 0.</param>
     public FieldAttribute(int order)
     {
+        Order = order;
     }
+
+    /// <summary>
+    /// The order of the field when serializing or deserializing the packet. Starts from 0.
+    /// </summary>
+    public int Order { get; }
 }

--- a/Obsidian/Serialization/Attributes/VarLengthAttribute.cs
+++ b/Obsidian/Serialization/Attributes/VarLengthAttribute.cs
@@ -1,6 +1,10 @@
 ﻿namespace Obsidian.Serialization.Attributes;
 
+/// <summary>
+/// Indicates that the field or property is in VarInt or VarLong format, or the method returns a VarInt
+/// or VarLong value. See <see href="https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Data_types#VarInt_and_VarLong"/>.
+/// The applied field or property must be of type <see cref="int"/> or <see cref="long"/> and the applied
+/// method must return an <see cref="int"/> or <see cref="long"/>.
+/// </summary>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-public sealed class VarLengthAttribute : Attribute
-{
-}
+public sealed class VarLengthAttribute : Attribute { }


### PR DESCRIPTION
Implement some packets in the list in #85 :

* `HorsesScreenOpenPacket`
* `MerchantOffersPacket`
* `OpenSignEditorPacket`
* `PlayerCombatEndPacket`
* `PlayerCombatEnterPacket`
* `PlayerCombatKillPacket`
* `SetChunkCacheRadiusPacket`

Note: packets are "implemented" by creating their classes and filling their fields data, the server currently does not use them. Also add some XML documents to packets related API and attribute classes.

One more thing: That list has to be updated, e.g. `OpenBookPacket` has already been implemented, while player combat event packets were not implemented until this commit.

_Fun fact: I [corrected an error](https://minecraft.wiki/?title=Minecraft_Wiki%3AProjects%2Fwiki.vg_merge%2FProtocol&diff=2845095&oldid=2844929) on the Minecraft Wiki page when checking the java source code of minecraft as the reference :)_