### PR TITLE
Create the 'accepted_keys' folder on startup

### DIFF
--- a/Obsidian/Plugins/PluginManager.cs
+++ b/Obsidian/Plugins/PluginManager.cs
@@ -90,7 +90,7 @@ public sealed class PluginManager : IAsyncDisposable
 
     public async Task LoadPluginsAsync()
     {
-        var acceptedKeysPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "accepted_keys");
+        var acceptedKeysPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), ServerConstants.AcceptedKeysPath);
         var acceptedKeyFiles = Directory.GetFiles(acceptedKeysPath);
 
         using var rsa = RSA.Create();

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -190,6 +190,7 @@ public sealed partial class Server : IServer
 
         Directory.CreateDirectory(ServerConstants.PermissionPath);
         Directory.CreateDirectory(ServerConstants.PersistentDataPath);
+        Directory.CreateDirectory(ServerConstants.AcceptedKeysPath);
         Directory.CreateDirectory("plugins");
 
         StartTime = DateTimeOffset.Now;

--- a/Obsidian/ServerConstants.cs
+++ b/Obsidian/ServerConstants.cs
@@ -29,4 +29,5 @@ public static class ServerConstants
 
     public const string PersistentDataPath = "persistentdata";
     public const string PermissionPath = "permissions";
+    public const string AcceptedKeysPath = "accepted_keys";
 }


### PR DESCRIPTION
and use constant for that folder's name in line with the other folders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the accepted keys directory path configuration.
  * Ensured the accepted keys directory is created automatically during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->